### PR TITLE
EOS-12019: Update the efs interface to call new api for read and write

### DIFF
--- a/src/include/cortxfs.h
+++ b/src/include/cortxfs.h
@@ -108,6 +108,8 @@ int cfs_endpoint_scan(int (*cfs_scan_cb)(const struct cfs_endpoint_info *info,
 #define CFS_ROOT_INODE 2LL
 #define CFS_ROOT_UID 0
 
+#define ONE_MB (1024 * 1024)
+
 typedef unsigned long long int cfs_ino_t;
 
 #define STAT_MODE_SET   0x001


### PR DESCRIPTION
EOS-12019: Update the efs interface to call new api for read and write
Problem Description:
Update the code in cfs to use new dsal apis.
Solution Overview:
Updated cfs_read and cfs_write to use the new dsal apis.
Unit Test Cases:
CFS UT passes

Signed-off-by: Shipra <shipra.gupta@seagate.com>