### PR TITLE
EOS-12984: Add git commit SHA to RPMs of git repository cortx-fs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-*cortxfs.spec
-*cortxfs.pc
+*cortx-fs.spec
+*cortx-fs.pc

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,9 +28,8 @@ CORTXFS_VERSION=${CORTXFS_VERSION:-"$(cat $CORTXFS_SOURCE_ROOT/VERSION)"}
 
 
 # Select CORTXFS Build Version.
-# Superproject: derived from cortxfs version.
-# Local: taken from git rev.
-CORTXFS_BUILD_VERSION=${CORTXFS_BUILD_VERSION:-"$(git rev-parse --short HEAD)"}
+# Taken from git rev of cortx-fs repo.
+CORTXFS_BUILD_VERSION=$(git -C $CORTXFS_SOURCE_ROOT rev-parse --short HEAD)
 
 # Optional, CORTX-UTILS source location.
 # Superproject: uses pre-defined location.


### PR DESCRIPTION
## Problem Statement:
https://jts.seagate.com/browse/EOS-12984
EOS-12984: Add git commit SHA to RPMs of git repository cortx-fs.

## Problem Description:
When RPMs are built and generated via build-scripts of cortx-posix, the current path directory (PWD) fetched git commit SHA of the cortx-posix repo.
This makes it difficult to track the git build version of the individual repo.

## Solution:
The problem was solved by giving an explicit path to the git repo.
```
git -C <path_to_git_repo> rev-parse --short HEAD
```
## Tests

Before fix : 
```
cortx-fs-debuginfo-1.0.0-7e45dd6.el7.x86_64.rpm
cortx-fs-devel-1.0.0-7e45dd6.el7.x86_64.rpm
cortx-fs-1.0.0-7e45dd6.el7.x86_64.rpm
```
After fix :
```
cortx-fs-debuginfo-1.0.0-c479d58.el7.x86_64.rpm
cortx-fs-devel-1.0.0-c479d58.el7.x86_64.rpm
 cortx-fs-1.0.0-c479d58.el7.x86_64.rpm
```

## Companion PRs
https://github.com/Seagate/cortx-utils/pull/10
https://github.com/Seagate/cortx-nsal/pull/5
https://github.com/Seagate/cortx-dsal/pull/11
https://github.com/Seagate/cortx-fs-ganesha/pull/11
