### PR TITLE
EOS-13064 Modified truncate operation

### DIFF
--- a/src/cortxfs/cortxfs_fops.c
+++ b/src/cortxfs/cortxfs_fops.c
@@ -154,6 +154,7 @@ int cfs_truncate(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *ino,
 	int rc;
 	dstore_oid_t oid;
 	struct dstore *dstore = dstore_get();
+	struct dstore_obj *obj = NULL;
 	struct stat stat;
 	size_t old_size;
 	size_t new_size;
@@ -181,12 +182,13 @@ int cfs_truncate(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *ino,
 	RC_WRAP_LABEL(rc, out, cfs_setattr, cfs_fs, cred, ino, new_stat,
 		      new_stat_flags);
 
-
 	RC_WRAP_LABEL(rc, out, cfs_ino_to_oid, cfs_fs, ino, &oid);
-	RC_WRAP_LABEL(rc, out, dstore_obj_resize, dstore, cfs_fs,
-		      &oid, old_size, new_size);
-
+	RC_WRAP_LABEL(rc, out, dstore_obj_open, dstore, &oid, &obj);
+	RC_WRAP_LABEL(rc, out, dstore_obj_resize, obj, old_size, new_size);
 out:
+	if (obj != NULL) {
+		dstore_obj_close(obj);
+	}
 	return rc;
 }
 


### PR DESCRIPTION
# Cortx-fs Change Summary

## Problem Statement

_[EOS-13064](https://jts.seagate.com/browse/EOS-13064):_
_Do the code clean up and remove old code in dsal.._

## Problem Description

_We have some of the legacy still reside in our repository which was  not being used so cleanup of that was required. During cleanup it was also found that the API which we intend to remove was still in use by truncate operation._

## Solution Overview

_So modified the truncate operation, cleanup the code wherever it was possible_

## Unit Test Cases
_All the DSAL, NSAL, Cortx-fs UTs are passing_
_Able to create, export and mount the FS, able to do basic I/O_
_cthon test is passing General, Basic, Lock test cases_
_Verified the truncate operation from NFS client and it is working, for further details about test cases visit [EOS-13064](https://jts.seagate.com/browse/EOS-13064)_

## Companion MRs
- https://github.com/Seagate/cortx-dsal/pull/12
- https://github.com/Seagate/cortx-utils/pull/11

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [x] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _As mentioned in description existing UTs are passing and related test cases are passing_
- [x] **Documentation:** _This patch, merge request, Jira ticket [EOS-13064](https://jts.seagate.com/browse/EOS-13064) have up to date description_