### PR TITLE
EOS-8938: Implemented New FH structure and it's API

### DIFF
--- a/src/cortxfs/cortxfs_internal.c
+++ b/src/cortxfs/cortxfs_internal.c
@@ -305,22 +305,6 @@ out:
 	return rc;
 }
 
-int cfs_set_stat(struct kvnode *node)
-{
-	int rc = 0;
-
-	dassert(node);
-	dassert(node->tree);
-	dassert(node->basic_attr);
-
-	rc = kvnode_dump(node);
-
-	log_trace("cfs_set_stat" NODE_ID_F "rc : %d",
-		  NODE_ID_P(&node->node_id), rc);
-
-	return rc;
-}
-
 int cfs_del_stat(struct kvnode *node)
 {
 	int rc;

--- a/src/cortxfs/cortxfs_internal.h
+++ b/src/cortxfs/cortxfs_internal.h
@@ -95,15 +95,6 @@ int cfs_kvnode_init(struct kvnode *node, struct kvtree *tree,
 int cfs_kvnode_load(struct kvnode *node, struct kvtree *tree,
 		    const cfs_ino_t *ino);
 
-/* Store the stat associated with particular file inode held by given kvnode
- *
- * @param[in] node *    - Kvnode pointer which is already initialized and hold
- *                        the stat attributes which needs to be stored
- *
- * @return - 0 on sucess on failure error code given by kvnode APIs
- */
-int cfs_set_stat(struct kvnode *node);
-
 /* Extract the stat attribute for particular file held by given kvnode
  *
  * @param[in] node *     - Kvnode pointer which is already initialzed and having

--- a/src/include/cortxfs.h
+++ b/src/include/cortxfs.h
@@ -320,15 +320,14 @@ int cfs_access(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
                const cfs_ino_t *ino, int flags);
 
 /** A upper layer callback to be used in cfs_readddir_cb fucntion.
- * @param[in, out] ctx       - Callback state
- * @param[in]     name       - Name of the dentry
- * @param[in]     child_stat - stat attributes of particular dentry to be used
- *                             in callback
+ * @param[in, out] ctx        - Callback state
+ * @param[in]     name        - Name of the dentry
+ * @param[in]     child_inode - inode number of a child
  * @retval true continue iteration.
  * @retval false stop iteration.
  */
 typedef bool (*cfs_readdir_cb_t)(void *ctx, const char *name,
-                                 const struct stat *child_stat);
+                                 cfs_ino_t child_ino);
 
 /* Walk over a directory "dir_ino" and call cb(cb_ctx, entry_name, node) which
  * will make a call to upper layer cb(cb_ctx, entry_name, child_stat) for
@@ -569,6 +568,26 @@ int cfs_link(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *ino,
  * NOTE: It does nothing if the object has one or more links.
  */
 int cfs_destroy_orphaned_file(struct cfs_fs *cfs_fs, const cfs_ino_t *ino);
+
+/* Return the reference of the stat attribute for particular file held by given
+ * kvnode, any update to this reference will always be visible inside kvnode
+ * Caller has to make sure before finalization of given kvnode, updated stat has
+ * been written to backend object store
+ * @param[in] node *     - Kvnode pointer which is already initialzed and having
+ *                         stat attributes
+ *
+ * @return - A pointer to stat attribute, this API not suppose to fail
+ */
+struct stat *cfs_get_stat2(const struct kvnode *node);
+
+/* Store the stat associated with particular file inode held by given kvnode
+ *
+ * @param[in] node *    - Kvnode pointer which is already initialized and hold
+ *                        the stat attributes which needs to be stored
+ *
+ * @return - 0 on sucess on failure error code given by kvnode APIs
+ */
+int cfs_set_stat(struct kvnode *node);
 
 /* Xattr APIs */
 /**

--- a/src/test/ut/ut_cortxfs_dir_ops.c
+++ b/src/test/ut/ut_cortxfs_dir_ops.c
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
  */
 
 #include "ut_cortxfs_helper.h"
@@ -36,7 +36,7 @@ struct readdir_ctx {
  * Call-back function for readdir
  */
 static bool test_readdir_cb(void *ctx, const char *name,
-                            const struct stat *stat)
+                            cfs_ino_t child_ino)
 {
 	struct readdir_ctx *readdir_ctx = ctx;
 


### PR DESCRIPTION
# Cortx-fs Change Summary

## Problem Statement

_[EOS-8938](https://jts.seagate.com/browse/EOS-8938):_
_EOS-NFS: Implement File handle structure and ops_

## Problem Description

_As of now in corts-fs, FH is not being used in all API, that leads to unnecessary calls to back as well as there are consistency and concurrency problems exist as of now_

## Solution Overview

_To overcome the performance, concurrency and consistency  problem we decided to modify FH in a such a way that in long term it will resolve all of the problem, so to achieve that this is the first step to create a new FH, modify the existing places which are using FH and make things works, slowly with future task in hand FH will be passed over all of the cortxfs API, so that each API can use the cached value from FH instead of getting it from back end store, also rest of the problem can also be addressed using FH, for more information refer ticket [EOS-8938](https://jts.seagate.com/browse/EOS-8938) and [EOS-8936](https://jts.seagate.com/browse/EOS-8936)_

## Unit Test Cases
_All the UTs are passing_
_Able to create, export and mount the FS, able to do basic I/O_
_cthon test is passing General, Basic, Lock test cases_

## Companion MRs
- https://github.com/Seagate/cortx-fs-ganesha/pull/13
- https://github.com/Seagate/cortx-nsal/pull/8

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [x] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _As mentioned in description existing UTs are passing and related test cases are passing_
- [x] **Documentation:** _This patch, merge request, Jira ticket [EOS-8938](https://jts.seagate.com/browse/EOS-8938) have up to date description_