### PR TITLE
EOS-11346 : Consider all groups while checking for access

### DIFF
--- a/src/cortxfs/cortxfs_internal.c
+++ b/src/cortxfs/cortxfs_internal.c
@@ -104,7 +104,7 @@ int cfs_access_check(const cfs_cred_t *cred, const struct stat *stat,
 		     int flags)
 {
 	int check = 0;
-	int i;
+	int i, grp_count;
 	bool grp_match = false;
 
 	if (!stat || !cred)
@@ -115,7 +115,9 @@ int cfs_access_check(const cfs_cred_t *cred, const struct stat *stat,
 		return 0;
 
 	/* Check for matching group in group list */
-	for (i=0; i< cred->total_grps; i++) {
+	grp_count = (cred->total_grps <= CORTXFS_CRED_GRPS) ? \
+		    cred->total_grps : CORTXFS_CRED_GRPS;
+	for (i = 0; i < grp_count; i++) {
 		if (cred->grp_list[i] == stat->st_gid) {
 			grp_match = true;
 			break;

--- a/src/include/cortxfs.h
+++ b/src/include/cortxfs.h
@@ -169,9 +169,13 @@ enum cfs_file_type {
 	CFS_FT_SYMLINK = 3
 };
 
+/* Number of groups supported by CORTXFS */
+#define CORTXFS_CRED_GRPS 16
 typedef struct cfs_cred__ {
         uid_t uid;
         gid_t gid;
+	uint16_t total_grps;
+	gid_t grp_list[CORTXFS_CRED_GRPS];
 } cfs_cred_t;
 
 int cfs_access_check(const cfs_cred_t *cred, const struct stat *stat,

--- a/src/include/cortxfs.h
+++ b/src/include/cortxfs.h
@@ -172,8 +172,8 @@ enum cfs_file_type {
 /* Number of groups supported by CORTXFS */
 #define CORTXFS_CRED_GRPS 16
 typedef struct cfs_cred__ {
-        uid_t uid;
-        gid_t gid;
+	uid_t uid;
+	gid_t gid;
 	uint16_t total_grps;
 	gid_t grp_list[CORTXFS_CRED_GRPS];
 } cfs_cred_t;


### PR DESCRIPTION
# CORTXFS Change Summary

## Problem Statement

_[EOS-11346](https://jts.seagate.com/browse/EOS-11346):_
_CORTXFS FSAL incorrectly handling multiple groups_

## Problem Description

_CORTXFS code do not consider the passed on group list while checking access_

## Solution Overview

_Added code to parse the group list and determine the access_
NFS RPC passes the list of groups. Need to consider this list
while checking access on that file/directory.

### Companion PR
https://github.com/Seagate/cortx-fs-ganesha/pull/21

## Unit Test Cases
_cthon test is passing Basic, General test cases_

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _As mentioned related test cases are passing_