### PR TITLE
EOS-8896: NFS ADDB: NFS-only tracepoints for READ (repo cortxfs)

### DIFF
--- a/src/cortxfs/CMakeLists.txt
+++ b/src/cortxfs/CMakeLists.txt
@@ -10,6 +10,13 @@ include_directories(${CORTXUTILSINC})
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CORTX_CFLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CORTX_CFLAGS}")
 
+# Turns on ADDB-based TDSB wrappers.
+# When this flag is disabled, perfc TSDB code will be turned off.
+# When this flag is enabled, the utils module has to be
+# compiled with this flag enabled otherwise some of
+# the function calls will be undefined.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DENABLE_TSDB_ADDB")
+
 SET(cortxfs_LIB_SRCS
    cortxfs.c
    cortxfs_fh.c

--- a/src/cortxfs/cortxfs_fops.c
+++ b/src/cortxfs/cortxfs_fops.c
@@ -27,6 +27,7 @@
 #include <sys/param.h> /* DEV_SIZE */
 #include "kvtree.h"
 #include <errno.h>
+#include "operation.h"
 
 int cfs_creat(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent,
 	      char *name, mode_t mode, cfs_ino_t *newfile)
@@ -192,8 +193,9 @@ out:
 	return rc;
 }
 
-ssize_t cfs_read(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_file_open_t *fd,
-		 void *buf, size_t count, off_t offset)
+static inline ssize_t __cfs_read(struct cfs_fs *cfs_fs, cfs_cred_t *cred,
+				 cfs_file_open_t *fd, void *buf,
+				 size_t count, off_t offset)
 {
 	int rc;
 	struct stat stat;
@@ -251,6 +253,23 @@ out:
 	kvnode_fini(&node);
 	log_trace("cfs_read: ino=%llu fd=%p count=%lu offset=%ld rc=%d",
 		  fd->ino, fd, count, (long)offset, rc);
+	return rc;
+}
+
+ssize_t cfs_read(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_file_open_t *fd,
+		 void *buf, size_t count, off_t offset)
+{
+	size_t rc;
+
+	perfc_trace_inii(PFT_CFS_READ, PEM_CFS_TO_NFS);
+	perfc_trace_attr(PEA_R_C_COUNT, count);
+	perfc_trace_attr(PEA_R_C_OFFSET, offset);
+
+	rc = __cfs_read(cfs_fs, cred, fd, buf, count, offset);
+
+	perfc_trace_attr(PEA_R_C_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_VERIFY);
+
 	return rc;
 }
 

--- a/src/cortxfs/cortxfs_ops.c
+++ b/src/cortxfs/cortxfs_ops.c
@@ -30,6 +30,7 @@
 #include "cortxfs_internal.h" /* dstore_obj_delete() */
 #include <common.h> /* likely */
 #include "kvtree.h"
+#include "operation.h"
 
 /* Internal cortxfs structure which holds the information given
  * by upper layer in case of readdir operation
@@ -73,8 +74,8 @@ int cfs_set_stat(struct kvnode *node)
 	return rc;
 }
 
-int cfs_getattr(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
-		const cfs_ino_t *ino, struct stat *bufstat)
+static int __cfs_getattr(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
+			 const cfs_ino_t *ino, struct stat *bufstat)
 {
 	int rc;
 	struct stat *stat = NULL;
@@ -92,6 +93,21 @@ int cfs_getattr(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
 out:
 	kvnode_fini(&node);
 	log_debug("ino=%d rc=%d", (int)bufstat->st_ino, rc);
+	return rc;
+}
+
+int cfs_getattr(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
+		const cfs_ino_t *ino, struct stat *bufstat)
+{
+	size_t rc;
+
+	perfc_trace_inii(PFT_CFS_GETATTR, PEM_CFS_TO_NFS);
+
+	rc = __cfs_getattr(cfs_fs, cred, ino, bufstat);
+
+	perfc_trace_attr(PEA_GETATTR_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
 	return rc;
 }
 
@@ -169,8 +185,8 @@ out:
 	return rc;
 }
 
-int cfs_access(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
-	       const cfs_ino_t *ino, int flags)
+static int __cfs_access(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
+			const cfs_ino_t *ino, int flags)
 {
 	int rc = 0;
 	struct stat stat;
@@ -180,6 +196,22 @@ int cfs_access(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
 	RC_WRAP_LABEL(rc, out, cfs_getattr, cfs_fs, cred, ino, &stat);
 	RC_WRAP_LABEL(rc, out, cfs_access_check, cred, &stat, flags);
 out:
+	return rc;
+}
+
+int cfs_access(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
+	       const cfs_ino_t *ino, int flags)
+{
+	size_t rc;
+
+	perfc_trace_inii(PFT_CFS_ACCESS, PEM_CFS_TO_NFS);
+	perfc_trace_attr(PEA_ACCESS_FLAGS, flags);
+
+	rc = __cfs_access(cfs_fs, cred, ino, flags);
+
+	perfc_trace_attr(PEA_ACCESS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
 	return rc;
 }
 


### PR DESCRIPTION
# EOS-8896: NFS ADDB: NFS-only tracepoints for READ (repo cortxfs)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## Commit Message
            commit e92e9216b4f498dc506df7471692383acdd81295
            Author: pratyush-seagate <pratyush.k.khan@seagate.com>
            Date:   Mon Sep 28 22:55:53 2020 -0600

            EOS-8896: NFS ADDB: NFS-only tracepoints for READ (repo cortxfs)
        List of modified files:
                modified:   src/cortxfs/CMakeLists.txt
                modified:   src/cortxfs/cortxfs_fops.c
                modified:   src/cortxfs/cortxfs_ops.c
            Change description:
                    Add new performance counters and integrate them further with other modules using newly added APIs
                    Addb APIs integration for read path
            Unit test:
                    Compilation with and without ENABLE_TSDB_ADDB flag
                    Addb unit test while integrated with read handler
                    Regular UTs (both with and without ENABLE_TSDB_ADDB flag)
            addb dump o/p from read handler after integration:
            * 2020-09-29-17:27:47.484505618            210ab ?               1?, ?               1?, ?            5035?, ?               1?
            * 2020-09-29-17:27:47.484506598            210cd ?               1?, ?               2?, ?            5035?, ?               5?, ?               0?
            * 2020-09-29-17:27:47.484507284            210cd ?               1?, ?               2?, ?            5035?, ?               6?, ?               1?
            * 2020-09-29-17:27:47.484508075            210cd ?               1?, ?               2?, ?            5035?, ?               7?, ?            1000?
            * 2020-09-29-17:27:47.484524037            210ab ?               4?, ?               1?, ?            5036?, ?               1?
            * 2020-09-29-17:27:47.484524850            210ef ?               4?, ?               3?, ?               6?, ?            5036?, ?            5035?
            * 2020-09-29-17:27:47.484525701            210cd ?               4?, ?               2?, ?            5036?, ?               a?, ?            1000?
            * 2020-09-29-17:27:47.484526538            210cd ?               4?, ?               2?, ?            5036?, ?               b?, ?               0?
            * 2020-09-29-17:27:47.484528239            210ab ?               2?, ?               1?, ?            5037?, ?               1?
            * 2020-09-29-17:27:47.484528994            210ef ?               2?, ?               3?, ?              10?, ?            5037?, ?            5035?
            * 2020-09-29-17:27:47.484529869            210cd ?               2?, ?               2?, ?            5037?, ?              10?, ?              12?
            * 2020-09-29-17:27:47.484531526            210cd ?               2?, ?               2?, ?            5037?, ?              11?, ?               0?
            * 2020-09-29-17:27:47.484532228            210ab ?               2?, ?               1?, ?            5037?, ?               2?
            * 2020-09-29-17:27:47.484533046            210ab ?               3?, ?               1?, ?            5038?, ?               1?
            * 2020-09-29-17:27:47.484533789            210ef ?               3?, ?               3?, ?              10?, ?            5038?, ?            5035?
            * 2020-09-29-17:27:47.484534649            210cd ?               3?, ?               2?, ?            5038?, ?              17?, ?              12?
            * 2020-09-29-17:27:47.484535507            210cd ?               3?, ?               2?, ?            5038?, ?              18?, ?               0?
            * 2020-09-29-17:27:47.487947750            210cd ?               3?, ?               2?, ?            5038?, ?              19?, ?               0?
            * 2020-09-29-17:27:47.487948775            210ab ?               3?, ?               1?, ?            5038?, ?               2?
