### PR TITLE
EOS-8996: Modified file creat path to use FH, fixed issue of FH dumping the stale stat attributes

### DIFF
--- a/src/cortxfs/cortxfs_fh.c
+++ b/src/cortxfs/cortxfs_fh.c
@@ -97,8 +97,16 @@ struct cfs_fh_serialized {
 	cfs_ino_t ino_num;
 };
 
+struct cfs_fs *cfs_fs_from_fh(const struct cfs_fh *fh)
+{
+	dassert(fh);
+	dassert(cfs_fh_invariant(fh));
+	return fh->fs;
+}
+
 struct stat *cfs_fh_stat(const struct cfs_fh *fh)
 {
+	dassert(fh);
 	return cfs_get_stat2(&fh->f_node);
 }
 
@@ -124,7 +132,7 @@ int cfs_fh_from_ino(struct cfs_fs *fs, const cfs_ino_t *ino_num,
 	struct kvstore *kvstor =  kvstore_get();
 	struct kvnode node = KVNODE_INIT_EMTPY;
 
-	dassert(kvstor);
+	dassert(kvstor && fs && ino_num && fh);
 
 	/* A caller for this API who uses/caches this FH, will be responsible
 	 * for freeing up this FH, caller should be calling cfs_fh_destroy to
@@ -141,6 +149,7 @@ int cfs_fh_from_ino(struct cfs_fs *fs, const cfs_ino_t *ino_num,
 	newfh->f_node = node;
 	newfh->fs = fs;
 	cfs_fh_init_key(newfh);
+	dassert(cfs_fh_invariant(newfh));
 	*fh = newfh;
 	newfh = NULL;
 out:
@@ -163,9 +172,9 @@ int cfs_fh_lookup(const cfs_cred_t *cred, struct cfs_fh *parent_fh,
 	node_id_t pid, id;
 
 	dassert(cred && parent_fh && name && fh && kvstor);
+	dassert(cfs_fh_invariant(parent_fh));
 
 	parent_stat = cfs_fh_stat(parent_fh);
-	dassert(parent_stat != NULL);
 
 	RC_WRAP_LABEL(rc, out, cfs_access_check,
 		      (cfs_cred_t *) cred, parent_stat, CFS_ACCESS_READ);
@@ -194,6 +203,7 @@ int cfs_fh_lookup(const cfs_cred_t *cred, struct cfs_fh *parent_fh,
 	newfh->fs = parent_fh->fs;
 	newfh->f_node = node;
 	cfs_fh_init_key(newfh);
+	dassert(cfs_fh_invariant(newfh));
 	*fh = newfh;
 	newfh = NULL;
 
@@ -209,14 +219,32 @@ void cfs_fh_destroy(struct cfs_fh *fh)
 {
 	struct kvstore *kvstor = kvstore_get();
 
-	dassert(kvstor);
+	dassert(kvstor && fh);
 	dassert(cfs_fh_invariant(fh));
 
-	if (fh) {
-		cfs_set_stat(&fh->f_node);
-		kvnode_fini(&fh->f_node);
-		kvs_free(kvstor, fh);
-	}
+	/* Note: As of now, destroying FH does not update the stats in backend
+	 * because those are stale, the reason for that is FH is not supplied
+	 * as input param to each of the cortxfs API which can modify the stats
+	 * of file directly in FH.
+	 * TODO: Temp_FH_op - to be removed
+	 * Uncomment the logic to dump the stats associated with FH once FH is
+	 * present everywhere all the update happens to FH
+	 */
+	/* cfs_set_stat(&fh->f_node); */
+	kvnode_fini(&fh->f_node);
+	kvs_free(kvstor, fh);
+}
+
+void cfs_fh_destroy_and_dump_stat(struct cfs_fh *fh)
+{
+	struct kvstore *kvstor = kvstore_get();
+
+	dassert(kvstor && fh);
+	dassert(cfs_fh_invariant(fh));
+
+	cfs_set_stat(&fh->f_node);
+	kvnode_fini(&fh->f_node);
+	kvs_free(kvstor, fh);
 }
 
 int cfs_fh_getroot(struct cfs_fs *fs, const cfs_cred_t *cred,
@@ -227,10 +255,11 @@ int cfs_fh_getroot(struct cfs_fs *fs, const cfs_cred_t *cred,
 	struct stat *stat = NULL;
 	cfs_ino_t root_ino = CFS_ROOT_INODE;
 
+	dassert(fs && cred && pfh);
+
 	RC_WRAP_LABEL(rc, out, cfs_fh_from_ino, fs, &root_ino, &fh);
 
 	stat = cfs_fh_stat(fh);
-	dassert(stat != NULL);
 
 	RC_WRAP_LABEL(rc, out, cfs_access_check,
 		      (cfs_cred_t *) cred, stat, CFS_ACCESS_READ);
@@ -251,6 +280,7 @@ int cfs_fh_serialize(const struct cfs_fh *fh, void* buffer, size_t max_size)
 	struct stat *stat = NULL;
 	struct cfs_fh_serialized data = { .ino_num = 0 };
 
+	dassert(fh && buffer);
 	dassert(cfs_fh_invariant(fh));
 
 	if (max_size < sizeof(struct cfs_fh_serialized)) {
@@ -259,7 +289,6 @@ int cfs_fh_serialize(const struct cfs_fh *fh, void* buffer, size_t max_size)
 	}
 
 	stat = cfs_fh_stat(fh);
-	dassert(stat);
 	data.ino_num = (cfs_ino_t)stat->st_ino;
 	/* fsid is ignored */
 
@@ -277,6 +306,8 @@ int cfs_fh_deserialize(struct cfs_fs *fs,
 {
 	int rc = 0;
 	struct cfs_fh_serialized data = { .ino_num = 0 };
+
+	dassert(fs && cred && buffer && pfh);
 
 	/* FIXME: We need to check if this function is a subject
 	 * to access checks.
@@ -310,6 +341,7 @@ int cfs_fh_ser_with_fsid(const struct cfs_fh *fh, uint64_t fsid, void *buffer,
 	struct stat *stat = NULL;
 	struct cfs_fh_serialized data = { .ino_num = 0 };
 
+	dassert(fh && buffer);
 	dassert(cfs_fh_invariant(fh));
 
 	if (max_size < sizeof(struct cfs_fh_serialized)) {
@@ -318,7 +350,6 @@ int cfs_fh_ser_with_fsid(const struct cfs_fh *fh, uint64_t fsid, void *buffer,
 	}
 
 	stat = cfs_fh_stat(fh);
-	dassert(stat != NULL);
 	data.ino_num = stat->st_ino;;
 	data.fsid = fsid;
 
@@ -331,6 +362,7 @@ out:
 
 void cfs_fh_key(const struct cfs_fh *fh, void **pbuffer, size_t *psize)
 {
+	dassert(fh && pbuffer && psize);
 	*pbuffer = (void *) &fh->key;
 	*psize = sizeof(fh->key);
 }

--- a/src/cortxfs/cortxfs_fops.c
+++ b/src/cortxfs/cortxfs_fops.c
@@ -14,13 +14,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
  */
 
 #include <string.h> /* memset */
 #include <kvstore.h> /* kvstore */
 #include <dstore.h> /* dstore */
 #include <cortxfs.h> /* cfs_access */
+#include "cortxfs_fh.h"
 #include "cortxfs_internal.h" /* cfs_set_ino_oid */
 #include <common/log.h> /* log_* */
 #include <common/helpers.h> /* RC_* */
@@ -29,29 +30,49 @@
 #include <errno.h>
 #include "operation.h"
 
-int cfs_creat(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent,
-	      char *name, mode_t mode, cfs_ino_t *newfile)
+int cfs_creat(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent_ino,
+              char *name, mode_t mode, cfs_ino_t *newfile_ino)
 {
+	int rc;
 	dstore_oid_t  oid;
+	struct cfs_fh *parent_fh = NULL;
+	struct stat *parent_stat = NULL;
 	struct dstore *dstore = dstore_get();
 
 	dassert(dstore);
 
-	log_trace("ENTER: parent=%p name=%s file=%p mode=0x%X",
-		  parent, name, newfile, mode);
+	/* TODO:Temp_FH_op - to be removed
+	 * Should get rid of creating and destroying FH operation in this
+	 * API when caller pass the valid FH instead of inode number
+	 */
+	RC_WRAP_LABEL(rc, out, cfs_fh_from_ino, cfs_fs, parent_ino, &parent_fh);
 
-	RC_WRAP(cfs_access, cfs_fs, cred, parent, CFS_ACCESS_WRITE);
+	parent_stat = cfs_fh_stat(parent_fh);
+
+	RC_WRAP_LABEL(rc, out, cfs_access_check, cred, parent_stat,
+		      CFS_ACCESS_WRITE);
+
 	/* Create tree entries, get new inode */
-	RC_WRAP(cfs_create_entry, cfs_fs, cred, parent, name, NULL,
-		mode, newfile, CFS_FT_FILE);
+	RC_WRAP_LABEL(rc, out, cfs_create_entry, parent_fh, cred, name, NULL,
+		      mode, newfile_ino, CFS_FT_FILE);
+
 	/* Get new unique extstore kfid */
-	RC_WRAP(dstore_get_new_objid, dstore, &oid);
+	RC_WRAP_LABEL(rc, out, dstore_get_new_objid, dstore, &oid);
+
 	/* Set the ino-kfid key-val in kvs */
-	RC_WRAP(cfs_set_ino_oid, cfs_fs, newfile, &oid);
+	RC_WRAP_LABEL(rc, out, cfs_set_ino_oid, cfs_fs, newfile_ino, &oid);
+
 	/* Create the backend object with passed kfid */
-	RC_WRAP(dstore_obj_create, dstore, cfs_fs, &oid);
-	log_trace("EXIT");
-	return 0;
+	RC_WRAP_LABEL(rc, out, dstore_obj_create, dstore, cfs_fs, &oid);
+
+out:
+	if (parent_fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(parent_fh);
+	}
+
+	log_trace("parent_ino=%llu name=%s newfile_ino=%llu rc=%d",
+		  *parent_ino, name, *newfile_ino, rc);
+	return rc;
 }
 
 int cfs_creat_ex(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent,
@@ -64,7 +85,8 @@ int cfs_creat_ex(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent,
 	struct kvstore *kvstor = kvstore_get();
 	struct kvs_idx index;
 
-	dassert(kvstor);
+	dassert(kvstor && cfs_fs && parent && name && stat_in && newfile &&
+		stat_out);
 
 	index = cfs_fs->kvtree->index;
 

--- a/src/include/cortxfs.h
+++ b/src/include/cortxfs.h
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
  */
 
 #ifndef _CFS_H
@@ -33,6 +33,7 @@
 
 /* forword declations */
 struct kvs_idx;
+struct cfs_fh;
 
 struct cfs_fs {
 	struct namespace *ns; /* namespace object */
@@ -191,9 +192,9 @@ typedef void *cfs_fs_ctx_t;
 /* Inode Attributes API */
 int cfs_amend_stat(struct stat *stat, int flags);
 
-int cfs_create_entry(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent,
-                     char *name, char *lnk, mode_t mode,
-                     cfs_ino_t *new_entry, enum cfs_file_type type);
+int cfs_create_entry(struct cfs_fh *parent_fh, cfs_cred_t *cred, char *name,
+                     char *lnk, mode_t mode, cfs_ino_t *new_entry,
+                     enum cfs_file_type type);
 
 /******************************************************************************/
 /** Change the name of a link between a parent node and a child node without

--- a/src/include/cortxfs_fh.h
+++ b/src/include/cortxfs_fh.h
@@ -146,17 +146,39 @@ int cfs_fh_lookup(const cfs_cred_t *cred,
 int cfs_fh_getroot(struct cfs_fs *fs, const cfs_cred_t *cred,
                    struct cfs_fh **pfh);
 
-/* Dump the file attributes(kvnode) associated with a given FH
+/* Note: As of now, destroying FH does not update the stats in backend because
+ * those are stale, the reason for that is FH is not supplied as input param to
+ * each of the cortxfs API which can modify the stats of file directly in FH.
+ * TODO: Temp_FH_op - to be removed
+ * Uncomment the logic to dump the stats associated with FH once FH is present
+ * everywhere all the update happens to FH
+ * Dump the file attributes(kvnode) associated with a given FH
  * Release all resources and deallocate the memory region allocted for this FH
  * @param[in] fh - Any initialized FH.
  */
 void cfs_fh_destroy(struct cfs_fh *fh);
+
+/* Note: This is a temporary API and shall be removed once FH is given as input
+ * to all the operation in FS and all the updates(like stats of file) happens
+ * to the FH
+ * TODO: Temp_FH_op - to be removed
+ * Dump the file attributes(kvnode) associated with a given FH
+ * Release all resources and deallocate the memory region allocted for this FH
+ * @param[in] fh - Any initialized FH.
+ */
+void cfs_fh_destroy_and_dump_stat(struct cfs_fh *fh);
 
 /* Get a pointer to inode numuber of a File Handle.
  * @param[in] fh - Any initialized FH.
  * @return Pointer to internal buffer which holds inode number.
  */
 cfs_ino_t *cfs_fh_ino(struct cfs_fh *fh);
+
+/* Get a pointer to file system context from a File Handle.
+ * @param[in] fh - Any initialized FH.
+ * @return Pointer to FS context.
+ */
+struct cfs_fs *cfs_fs_from_fh(const struct cfs_fh *fh);
 
 /* Get a pointer to attributes (stat) of a File Handle.
  * @param[in] fh - Any initialized FH.


### PR DESCRIPTION
# Cortx-fs Change Summary

## Problem Statement

_[EOS-8996](https://jts.seagate.com/browse/EOS-8996):_
_EOS-NFS: Update the cfs_creat API to use FH_
_[EOS-7920](https://jts.seagate.com/browse/EOS-7920):_
_'nfs-ganesha' service getting down after executing simultaneous multiple Namespace operations with automation script._

## Problem Description

_File creation APIs needed to be modified to work on FH_
_Because of recent change in FH, FH was dumping the stale stat to kvstore which leads to a problem of ganesha crashing_

## Solution Overview

_As FH is not present everywhere as of now I have created a temporary FH in start of cfs_mkdir, cfs_symlink, cfs_creat API and modified the rest of the functionality within these API to use FH. Once FH will be supplied from the caller to all of these three APIs temporary construction and destruction of FH will be removed. Along with these changes I have fixed issue of FH dumping the stale stat for file in to kvstore mentioned in [EOS-7290](https://jts.seagate.com/browse/EOS-7290)_

## Unit Test Cases
_All UTs are passing_
_Able to create FS, mount FS and do basic I/O on that_
_Cthon is passing_
_Following steps are working as expected and output of this step has been added here as a testing summary_

1. sudo mount -o vers=4.0 127.0.0.1:/fs1 /tmp/mnt_dir/
2. cd /tmp/mnt_dir/
3. echo `date` > "file1"
4. mkdir dir1
5. for i in {1..5} ; do ln file1 dir1/link$i ; done
6. stat file1

## Note: 
_I have mounted /var/motr separately in order to avoid /var/motr is getting 100% full_



## Testing
<details>
  <summary>Click here to see the test execution output</summary>

```
# touch file1
[root@ssc-vm-0115: dir1 ]#
# ls
file1
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 0               Blocks: 0          IO Block: 1048576 regular empty file
Device: 2ch/44d Inode: 7           Links: 1
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:40:35.362265817 -0600
Change: 2020-10-11 22:40:35.362267000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# mkdir dir1
[root@ssc-vm-0115: dir1 ]#
# ls
dir1  file1
[root@ssc-vm-0115: dir1 ]#
# echo `date` > file1
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 1
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:41:01.899546000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# for i in {1..5} ; do ln file1 dir1/link$i ; done
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 6
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:41:17.903080000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# rm dir1/link1
rm: remove regular file ‘dir1/link1’? y
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 5
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:41:49.540530000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# rm dir1/link2
rm: remove regular file ‘dir1/link2’? y
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 4
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:42:01.381457000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# ls
dir1  file1
[root@ssc-vm-0115: dir1 ]#
# cd dir1/
[root@ssc-vm-0115: dir1 ]#
# ls
link3  link4  link5
[root@ssc-vm-0115: dir1 ]#
# ls -lsi
total 2
7 1 -rw-r--r--. 4 root root 29 Oct 11 22:41 link3
7 1 -rw-r--r--. 4 root root 29 Oct 11 22:41 link4
7 1 -rw-r--r--. 4 root root 29 Oct 11 22:41 link5
[root@ssc-vm-0115: dir1 ]#
# cd ../
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 4
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:42:01.381457000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# rm dir1/link
link3  link4  link5
[root@ssc-vm-0115: dir1 ]#
# rm dir1/link3
rm: remove regular file ‘dir1/link3’? y
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 3
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:42:43.792214000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# rm dir1/link4
rm: remove regular file ‘dir1/link4’? y
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 2
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:42:53.528294000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# rm dir1/link5
rm: remove regular file ‘dir1/link5’? y
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 1
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:43:01.791946000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# cat file1
Sun Oct 11 22:41:01 MDT 2020
```
  
</details>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [ ] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _As mentioned in description all UTs and cthon is passing also @Shreya-18  has done the peer testing for the bug reported in [EOS-7290](https://jts.seagate.com/browse/EOS-7290)._
- [x] **Documentation:** _This patch, merge request, Jira ticket [EOS-13606](https://jts.seagate.com/browse/EOS-13606) have up to date description_