### PR TITLE
EOS-13985:Implement nfs_req.py and hist.py <cortxfs repo>

### DIFF
--- a/src/tools/addb/scripts/addb2db_cortxfs.py
+++ b/src/tools/addb/scripts/addb2db_cortxfs.py
@@ -72,7 +72,7 @@ class entity_attributes(BaseModel):
     entity_type = TextField()
     opid        = IntegerField()
     attr_name   = TextField()
-    attr_val    = IntegerField()
+    attr_val    = TextField()
 
 class entity_maps(BaseModel):
     pid         = IntegerField()
@@ -83,6 +83,7 @@ class entity_maps(BaseModel):
     map_name    = IntegerField()
     src_opid    = IntegerField()
     dst_opid    = IntegerField()
+    clr_opid    = IntegerField()
 
 db_create_delete_tables = [entity_states, entity_attributes, entity_maps]
 
@@ -170,7 +171,10 @@ class ADDB2PPNFS:
         ret['entity_type'] = row[4]
         ret['opid'] = int(row[5], 16)
         ret['attr_name'] = row[6]
-        ret['attr_val'] = int(row[8], 16)
+        if ret['attr_name'].find("attr_time") == -1:
+            ret['attr_val'] = int(row[7], 16)
+        else:
+            ret['attr_val'] = "NA"
         return((table, ret))
 
     # [ '*',
@@ -190,9 +194,9 @@ class ADDB2PPNFS:
         ret['fn_tag'] = row[3]
         ret['entity_type'] = row[4]
         ret['map_name'] = int(row[5], 16)
-        # ret['src_opid'] = int(row[6], 16)
-        ret['src_opid'] = 0
-        ret['dst_opid'] = int(row[8], 16)
+        ret['src_opid'] = int(row[6], 16)
+        ret['dst_opid'] = int(row[7], 16)
+        ret['clr_opid'] = int(row[8], 16)
         return((table, ret))
 
     def __init__(self):

--- a/src/tools/addb/scripts/cortxfs_hist.py
+++ b/src/tools/addb/scripts/cortxfs_hist.py
@@ -1,0 +1,119 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import argparse
+import sys
+from peewee import SqliteDatabase
+from matplotlib import pyplot as plt
+
+DB      = SqliteDatabase(None)
+BLOCK   = 16<<10
+PROC_NR = 48
+DBBATCH = 95
+PID     = 0
+
+def db_init(path):
+    DB.init(path, pragmas={
+        'journal_mode': 'memory',
+        'cache_size': -1024*1024*256,
+        'synchronous': 'off',
+    })
+
+def db_connect():
+    DB.connect()
+
+def db_close():
+    DB.close()
+
+def gen_perfc_op_hist_graph(fn_tag: str="fsal_read", op_file: str="cortxfs_perfc_graph"):
+    xvals_opids=[]
+    yvals_time=[]
+    xmax = 0
+    ymax = 0
+
+    with DB.atomic():
+        cursor = DB.execute_sql(f"SELECT DISTINCT opid from entity_states WHERE fn_tag LIKE \"{fn_tag}\" ORDER BY id ASC")
+        field_opids = list(cursor.fetchall())
+    label_opids = ("o");
+    opids = [dict(zip(label_opids, f)) for f in field_opids]
+
+    if opids == []:
+        print ("Could not find enough details in db for {0}", format(fn_tag))
+        return
+
+    for opid in opids:
+        with DB.atomic():
+            cursor = DB.execute_sql(f"SELECT * from entity_states WHERE opid = {opid['o']}")
+            field_states = list(cursor.fetchall())
+        label_states = ("id", "pid", "time", "tsdb_mod", "fn_tag", "entity_type", "opid", "state_type");
+        states = [dict(zip(label_states, f)) for f in field_states]
+        t0 = -1
+        t1 = -1
+        for state in states:
+            if state['state_type'] in "finish":
+                t1 = state['time']
+            if state['state_type'] in "init":
+                t0 = state['time']
+        if t0 == -1 or t1 == -1:
+            print (f"incomplete states, discarding this sample, {states}")
+        else:
+            time_diff = t1 - t0
+            # print (f"opid {opid['o']} took {time_diff} us to complete")
+            xvals_opids.append(opid['o'])
+            yvals_time.append(time_diff)
+            if xmax < opid['o']:
+                xmax = opid['o']
+            if ymax < time_diff:
+                ymax = time_diff
+
+    fig, ax = plt.subplots()
+    ax.bar([idx for idx in range(len(xvals_opids))], yvals_time, align='edge', color='Red', width=0.3)
+    ax.set_xticks([idx for idx in range(len(xvals_opids))])
+    ax.set_xticklabels(xvals_opids, rotation=90, ha='center', size=3)
+    ax.set_yticklabels(yvals_time, rotation=90, ha='left', size=3)
+    fig.tight_layout()
+    fig.subplots_adjust(bottom=0.2)
+    plt.title(f"{fn_tag} \n time")
+    plt.xlabel(f"{fn_tag} opid(s)")
+    plt.ylabel("time (us)")
+    plt.tight_layout()
+    plt.savefig(fname=op_file, format="svg")
+    print (f"Histogram graph render completed for operation {fn_tag}")
+
+    return
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(prog=sys.argv[0], description="""
+    cortxfs_hist.py: Display histogram graph of a provided cortxfs function.
+    """)
+    parser.add_argument("-d", "--db", type=str, default="cortxfs_perfc.db",
+                        help="Performance database (cortxfs_perfc.db)")
+    parser.add_argument("fn_tag", type=str, help="A valid fn_tag from CORTXFS stack which is enabled for performance profiling")
+    parser.add_argument("-o", "--op_graph", type=str, default="cortxfs_hist_graph.png",
+                        help="CORTXFS fn_tag histogram graph output file (cortxfs_hist_graph.png)")
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    args=parse_args()
+    db_init(args.db)
+    db_connect()
+    print('Creating cortxfs histogram graph for fn_tag {0}, from db file {1}, o/p graph file {2}'. format(args.fn_tag, args.db, args.op_graph))
+    gen_perfc_op_hist_graph(args.fn_tag, args.op_graph)
+    db_close()

--- a/src/tools/addb/scripts/cortxfs_req.py
+++ b/src/tools/addb/scripts/cortxfs_req.py
@@ -1,0 +1,162 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import sys
+from typing import Dict
+from graphviz import Digraph
+import argparse
+from peewee import SqliteDatabase
+
+DB      = SqliteDatabase(None)
+BLOCK   = 16<<10
+PROC_NR = 48
+DBBATCH = 95
+PID     = 0
+
+def db_init(path):
+    DB.init(path, pragmas={
+        'journal_mode': 'memory',
+        'cache_size': -1024*1024*256,
+        'synchronous': 'off',
+    })
+
+def db_connect():
+    DB.connect()
+
+def db_close():
+    DB.close()
+
+def graph_node_add(g: Digraph, name: str, header: str, attrs: Dict):
+    node_template="""<
+<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4">
+  <TR>
+    <TD>{}</TD>
+  </TR>
+  <TR>
+    <TD>{}</TD>
+  </TR>
+</TABLE>>
+"""
+    label = "<BR/>".join([f"{k}={v}" for (k,v) in attrs.items()])
+    g.node(name, node_template.format(header, label))
+
+def gen_perfc_op_call_graph(fsal_op_id: int=None, op_file: str="cortxfs_perfc_graph"):
+    ext_graph=None
+    label_maps = ("id", "pid", "time", "tsdb_mod", "fn_tag", "entity_type", "map_name", "src_opid", "dst_opid", "clr_opid");
+    label_attrs = ("id", "pid", "time", "tsdb_mod", "fn_tag", "entity_type", "opid", "attr_name", "attr_val");
+    label_states = ("id", "pid", "time", "tsdb_mod", "fn_tag", "entity_type", "opid", "state_type");
+
+    with DB.atomic():
+        cursor = DB.execute_sql(f"SELECT * from entity_states WHERE opid IN(SELECT ES.opid FROM entity_states ES JOIN entity_maps EM ON EM.src_opid = ES.opid AND EM.dst_opid = {fsal_op_id} OR ES.opid = {fsal_op_id} GROUP BY ES.opid) ORDER BY id ASC")
+        field_states = list(cursor.fetchall())
+
+        cursor = DB.execute_sql(f"SELECT * from entity_attributes WHERE opid IN(SELECT EA.opid FROM entity_attributes EA JOIN entity_maps EM ON EM.src_opid = EA.opid AND EM.dst_opid = {fsal_op_id} OR EA.opid = {fsal_op_id} GROUP BY EA.opid) ORDER BY id ASC")
+        field_attrs = list(cursor.fetchall())
+
+        cursor = DB.execute_sql(f"SELECT * from entity_maps where dst_opid = {fsal_op_id} ORDER BY id ASC")
+        field_maps = list(cursor.fetchall())
+
+    states = [dict(zip(label_states, f)) for f in field_states]
+    attrs = [dict(zip(label_attrs, f)) for f in field_attrs]
+    maps = [dict(zip(label_maps, f)) for f in field_maps]
+
+    if states == [] or attrs == [] or maps == []:
+        print ("Could not find enough details in db for OP ID", fsal_op_id)
+        return
+
+    graph = ext_graph if ext_graph is not None else Digraph(
+        strict=True, format='png', node_attr = {'shape': 'plaintext'})
+
+    for state in states:
+        if state['opid'] == fsal_op_id:
+            if state['state_type'] in "init":
+                # print (state['time'], state['fn_tag'], state['state_type'])
+                node_content = {'op start time': state['time']}
+                for attr in attrs:
+                    if attr['opid'] == state['opid']:
+                        # print (attr['attr_name'], attr['attr_val'])
+                        node_content.update({'opid' : attr['opid'], 'parent opid' : 0, attr['attr_name']:attr['attr_val']})
+                # print (node_content)
+                t0 = state['time']
+                graph_node_add(graph, f"init{state['opid']}", "{} {}".format(state['fn_tag'], state['state_type']), node_content)
+
+            if state['state_type'] in "finish":
+                # print (state['time'], state['fn_tag'], state['state_type'])
+                node_content = {'opid' : attr['opid'], 'parent opid' : 0, 'op end time': state['time']}
+                # print (node_content)
+                t1 = state['time']
+                graph_node_add(graph, f"finish{state['opid']}", "{} {}".format(state['fn_tag'], state['state_type']), node_content)
+                graph.edge(f"init{state['opid']}", f"finish{state['opid']}", label="{} us".format(str(t1 - t0)))
+
+    for mp in maps:
+        for state in states:
+            if state['opid'] == mp['src_opid']:
+                if state['state_type'] in "init":
+                    # print (state['time'], state['fn_tag'], state['state_type'])
+                    node_content = {'op start time': state['time']}
+                    for attr in attrs:
+                        if attr['opid'] == state['opid']:
+                            # print (attr['attr_name'], attr['attr_val'])
+                            node_content.update({'opid' : mp['src_opid'], 'parent opid' : mp['clr_opid'], attr['attr_name']:attr['attr_val']})
+                    # print (node_content)
+                    t0 = state['time']
+                    graph_node_add(graph, f"childinit{state['opid']}", "{} {}".format(state['fn_tag'], state['state_type']), node_content)
+
+                if state['state_type'] in "finish":
+                    # print (state['time'], state['fn_tag'], state['state_type'])
+                    node_content = {'opid' : mp['src_opid'], 'parent opid' : mp['clr_opid'], 'op end time': state['time']}
+                    # print (node_content)
+                    t1 = state['time']
+                    graph_node_add(graph, f"childfinish{state['opid']}", "{} {}".format(state['fn_tag'], state['state_type']), node_content)
+                    graph.edge(f"childinit{state['opid']}", f"childfinish{state['opid']}", label="{} us".format(str(t1 - t0)))
+
+    for mp in maps:
+        if mp['clr_opid'] == fsal_op_id:
+            graph.edge(f"init{mp['clr_opid']}", f"childinit{mp['src_opid']}")
+            graph.edge(f"childfinish{mp['src_opid']}", f"finish{mp['clr_opid']}")
+        else:
+            graph.edge(f"childinit{mp['clr_opid']}", f"childinit{mp['src_opid']}")
+            graph.edge(f"childfinish{mp['src_opid']}", f"childfinish{mp['clr_opid']}")
+
+    if ext_graph is None:
+        graph.render(op_file)
+
+    print ("Graph render completed")
+
+    return
+
+def parse_args():
+    parser = argparse.ArgumentParser(prog=sys.argv[0], description="""
+    cortxfs_req.py: Display significant performance counters for cortxfs stack.
+    """)
+    parser.add_argument("-d", "--db", type=str, default="cortxfs_perfc.db",
+                        help="Performance database (cortxfs_perfc.db)")
+    parser.add_argument("fsal_op_id", type=str, help="Operation id whose perf counters needs to be checked")
+    parser.add_argument("-o", "--op_graph", type=str, default="cortxfs_perfc_graph.png",
+                        help="CORTXFS Perfc operation callgraph output file (cortxfs_perfc_graph.png)")
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    args=parse_args()
+    fsal_op_id = int(args.fsal_op_id)
+    db_init(args.db)
+    db_connect()
+    print('Creating cortxfs performance call graphs for fsal_op_id {0}, from db file {1}, o/p graph png file {2}'. format(fsal_op_id, args.db, args.op_graph))
+    gen_perfc_op_call_graph(fsal_op_id, args.op_graph)
+    db_close()


### PR DESCRIPTION
# EOS-13985:Implement nfs_req.py and hist.py <cortxfs repo>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## Commit Message
        commit b93363c1eb1dbe08baf44ec412307d2b347ad2c6
        Author: pratyush-seagate <pratyush.k.khan@seagate.com>
        Date:   Mon Oct 12 17:05:15 2020 -0600

        EOS-13985:Implement nfs_req.py and hist.py <Part 1, cortxfs repo>
        List of modified files:
                modified:   src/tools/addb/scripts/addb2db_cortxfs.py
                new file:   src/tools/addb/scripts/cortxfs_req.py
                new file:   src/tools/addb/scripts/cortxfs_hist.py
        Change description:
                1. Add a python script named cortxfs_hist.py to generate histogram graphs with respect to operation and time from the perfor
                2. Add a python script named cortxfs_req.py to generate performance call graph based on the o/p generated by addb2db_cortxfs
                3. Update addb2db_cortxfs.py to track the operation id of immediate callers in map performance counters
        Unit test:
                Run NFS READ IO test, generate DB from addb2db_cortxfs.py, use that DB to find the fsal read op id which took most time to c
        TODO: Implement timeline tools
        The generate graph image along with DB file and raw dump files are saved at: /home/751521/JIRA/EOS-13985
                # python3 src/tools/addb/scripts/cortxfs_hist.py -d cortxfs_perfc_demo_decoded_1.db -o read_hist.svg fsal_read
                Creating cortxfs histogram graph for fn_tag fsal_read, from db file cortxfs_perfc_demo_decoded_1.db, o/p graph file read_his
                incomplete states, discarding this sample, [{'id': 4734, 'pid': 35, 'time': 1602494228965013040, 'tsdb_mod': 'fsuser_state',
    incomplete states, discarding this sample, [{'id': 5036, 'pid': 35, 'time': 1602494229051873985, 'tsdb_mod': 'fsuser_state', 'fn_tag': '
                Histogram graph render completed for operation fsal_read
                # python3 src/tools/addb/scripts/cortxfs_req.py -d ./cortxfs_perfc_demo_decoded_1.db 0x5C3F -o read_op_23615
                Creating cortxfs performance call graphs for fsal_op_id 23615, from db file ./cortxfs_perfc_demo_decoded_1.db, o/p graph png
                Graph render completed
