### PR TITLE
EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations

### DIFF
--- a/src/cortxfs/cortxfs_ops.c
+++ b/src/cortxfs/cortxfs_ops.c
@@ -74,7 +74,7 @@ int cfs_set_stat(struct kvnode *node)
 	return rc;
 }
 
-static int __cfs_getattr(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
+static inline int __cfs_getattr(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
 			 const cfs_ino_t *ino, struct stat *bufstat)
 {
 	int rc;
@@ -115,8 +115,8 @@ int cfs_getattr(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
 	return rc;
 }
 
-int cfs_setattr(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *ino,
-		struct stat *setstat, int statflag)
+static inline int __cfs_setattr(struct cfs_fs *cfs_fs, cfs_cred_t *cred,
+                         cfs_ino_t *ino, struct stat *setstat, int statflag)
 {
 	struct cfs_fh *fh = NULL;
 	struct stat *stat = NULL;
@@ -195,6 +195,20 @@ out:
 	return rc;
 }
 
+int cfs_setattr(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *ino,
+                struct stat *setstat, int statflag)
+{
+    size_t rc;
+
+    perfc_trace_inii(PFT_CFS_SETATTR, PEM_CFS_TO_NFS);
+
+    rc = __cfs_setattr(cfs_fs, cred, ino, setstat, statflag);
+
+    perfc_trace_attr(PEA_SETATTR_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
+    return rc;
+}
 static int __cfs_access(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
 			const cfs_ino_t *ino, int flags)
 {


### PR DESCRIPTION
Problem Statement
EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations
EOS-10522: NFS ADDB: Decoders for all file operations

Problem Description
Implement tracepoints and decoder for the attr handlers.

Solution Overview
Following changes has been done:

added wrapper over kvsfs_getattrs using kvsfs_perf_op_getattrs
Added traces for init and finish inside kvsfs_getattrs
Added traces for attributes like return code
added wrapper over kvsfs_setattrs using kvsfs_perf_op_setattrs
Added traces for init and finish inside kvsfs_setattrs
Added traces for attributes like return code
Added all enums in the decoder.
Unit Test Cases
`
sudo m0addb2dump -p /usr/lib64/libcortx-utils.so -- /addb_22028/o/100000000000000:2 | grep fsuser > addb_dump_op_decode_4

-bash-4.2$ cat addb_dump_op_decode_4 | grep "fsal_getattrs"

2020-10-08-01:13:36.571926218 fsuser_state fsal_getattrs, state, e, init
2020-10-08-01:13:36.576515604 fsuser_attribute fsal_getattrs, attribute, e, get_attribute_result_major_code, ? 0?
2020-10-08-01:13:36.576516264 fsuser_attribute fsal_getattrs, attribute, e, get_attribute_result_minor_code, ? 0?
2020-10-08-01:13:36.576516774 fsuser_state fsal_getattrs, state, e, finish
2020-10-08-01:14:01.444814040 fsuser_state fsal_getattrs, state, 36, init
2020-10-08-01:14:01.448805051 fsuser_attribute fsal_getattrs, attribute, 36, get_attribute_result_major_code, ? 0?
2020-10-08-01:14:01.448805701 fsuser_attribute fsal_getattrs, attribute, 36, get_attribute_result_minor_code, ? 0?
2020-10-08-01:14:01.448806226 fsuser_state fsal_getattrs, state, 36, finish
2020-10-08-01:14:16.542089191 fsuser_state fsal_getattrs, state, c3, init
2020-10-08-01:14:16.546121912 fsuser_attribute fsal_getattrs, attribute, c3, get_attribute_result_major_code, ? 0?
2020-10-08-01:14:16.546122558 fsuser_attribute fsal_getattrs, attribute, c3, get_attribute_result_minor_code, ? 0?
2020-10-08-01:14:16.546123094 fsuser_state fsal_getattrs, state, c3, finish
2020-10-08-01:14:29.730222059 fsuser_state fsal_getattrs, state, 17c, init
2020-10-08-01:14:29.734102240 fsuser_attribute fsal_getattrs, attribute, 17c, get_attribute_result_major_code, ? 0?
2020-10-08-01:14:29.734102870 fsuser_attribute fsal_getattrs, attribute, 17c, get_attribute_result_minor_code, ? 0?
2020-10-08-01:14:29.734103387 fsuser_state fsal_getattrs, state, 17c, finish
-bash-4.2$ cat addb_dump_op_decode_4 | grep "fsal_setattrs"

2020-10-08-01:14:34.079656624 fsuser_state fsal_setattrs, state, 566, init
2020-10-08-01:14:34.082418414 fsuser_attribute fsal_setattrs, attribute, 566, set_attribute_result_major_code, ? 0?
2020-10-08-01:14:34.082419134 fsuser_attribute fsal_setattrs, attribute, 566, set_attribute_result_minor_code, ? 0?
2020-10-08-01:14:34.082419712 fsuser_state fsal_setattrs, state, 566, finish
2020-10-08-01:14:33.909490008 fsuser_state fsal_setattrs, state, 492, init
2020-10-08-01:14:33.912997100 fsuser_attribute fsal_setattrs, attribute, 492, set_attribute_result_major_code, ? 0?
2020-10-08-01:14:33.912997868 fsuser_attribute fsal_setattrs, attribute, 492, set_attribute_result_minor_code, ? 0?
2020-10-08-01:14:33.912998408 fsuser_state fsal_setattrs, state, 492, finish
2020-10-08-01:14:55.922933569 fsuser_state fsal_setattrs, state, 7eb, init
2020-10-08-01:14:55.926658809 fsuser_attribute fsal_setattrs, attribute, 7eb, set_attribute_result_major_code, ? 0?
2020-10-08-01:14:55.926660101 fsuser_attribute fsal_setattrs, attribute, 7eb, set_attribute_result_minor_code, ? 0?
2020-10-08-01:14:55.926660668 fsuser_state fsal_setattrs, state, 7eb, finish
2020-10-08-01:14:52.125471046 fsuser_state fsal_setattrs, state, 76e, init
2020-10-08-01:14:52.128594395 fsuser_attribute fsal_setattrs, attribute, 76e, set_attribute_result_major_code, ? 0?
2020-10-08-01:14:52.128595145 fsuser_attribute fsal_setattrs, attribute, 76e, set_attribute_result_minor_code, ? 0?
2020-10-08-01:14:52.128595686 fsuser_state fsal_setattrs, state, 76e, finish