### PR TITLE
EOS-9005:Modified cfs_detach and cfs_destroy_orphaned_file to use FH

### DIFF
--- a/src/cortxfs/cortxfs_fh.c
+++ b/src/cortxfs/cortxfs_fh.c
@@ -110,12 +110,26 @@ struct stat *cfs_fh_stat(const struct cfs_fh *fh)
 	return cfs_get_stat2(&fh->f_node);
 }
 
+struct kvnode *cfs_kvnode_from_fh(struct cfs_fh *fh)
+{
+	dassert(fh);
+	dassert(cfs_fh_invariant(fh));
+	return &fh->f_node;
+}
+
 static inline
 void cfs_fh_init_key(struct cfs_fh *fh)
 {
 	struct stat *stat = cfs_fh_stat(fh);
 	fh->key.file = stat->st_ino;
 	fh->key.fs = fh->fs;
+}
+
+node_id_t *cfs_node_id_from_fh(struct cfs_fh *fh)
+{
+	dassert(fh);
+	dassert(cfs_fh_invariant(fh));
+	return &fh->f_node.node_id;
 }
 
 cfs_ino_t *cfs_fh_ino(struct cfs_fh *fh)

--- a/src/cortxfs/cortxfs_ops.c
+++ b/src/cortxfs/cortxfs_ops.c
@@ -500,24 +500,25 @@ static inline bool cfs_file_has_links(struct stat *stat)
 	return stat->st_nlink > 0;
 }
 
-int cfs_destroy_orphaned_file(struct cfs_fs *cfs_fs,
-			      const cfs_ino_t *ino)
+static int cfs_destroy_orphaned_file2(struct cfs_fh *fh)
 {
-
 	int rc;
-	struct stat *stat = NULL;
 	dstore_oid_t oid;
+	cfs_ino_t *ino = NULL;
+	struct cfs_fs *cfs_fs = NULL;
+	struct stat *stat = NULL;
+	struct kvnode *node = NULL;
 	struct kvstore *kvstor = kvstore_get();
 	struct dstore *dstore = dstore_get();
 	struct kvs_idx index;
-	struct kvnode node = KVNODE_INIT_EMTPY;
 
-	dassert(kvstor && dstore);
+	dassert(kvstor && dstore && fh);
+
+	cfs_fs = cfs_fs_from_fh(fh);
+	ino = cfs_fh_ino(fh);
+	stat = cfs_fh_stat(fh);
 
 	index = cfs_fs->kvtree->index;
-
-	RC_WRAP_LABEL(rc, out, cfs_kvnode_load, &node, cfs_fs->kvtree, ino);
-	RC_WRAP_LABEL(rc, out, cfs_get_stat, &node, &stat);
 
 	if (cfs_file_has_links(stat)) {
 		rc = 0;
@@ -526,11 +527,12 @@ int cfs_destroy_orphaned_file(struct cfs_fs *cfs_fs,
 
 	kvs_begin_transaction(kvstor, &index);
 
-	RC_WRAP_LABEL(rc, out, cfs_del_stat, &node);
+	node = cfs_kvnode_from_fh(fh);
+	RC_WRAP_LABEL(rc, out, cfs_del_stat, node);
 
 	if (S_ISLNK(stat->st_mode)) {
 		/* Delete symlink */
-		RC_WRAP_LABEL(rc, out, cfs_del_sysattr, &node,
+		RC_WRAP_LABEL(rc, out, cfs_del_sysattr, node,
 			      CFS_SYS_ATTR_SYMLINK);
 	} else if (S_ISREG(stat->st_mode)) {
 		RC_WRAP_LABEL(rc, out, cfs_ino_to_oid, cfs_fs, ino, &oid);
@@ -550,15 +552,32 @@ int cfs_destroy_orphaned_file(struct cfs_fs *cfs_fs,
 	kvs_end_transaction(kvstor, &index);
 
 out:
-	kvnode_fini(&node);
-	if (stat) {
-		kvs_free(kvstor, stat);
-	}
-
 	if (rc != 0) {
 		kvs_discard_transaction(kvstor, &index);
 	}
 
+	log_trace("inode=%llu rc=%d", *ino, rc);
+	return rc;
+}
+
+int cfs_destroy_orphaned_file(struct cfs_fs *cfs_fs,
+                              const cfs_ino_t *ino)
+{
+	int rc;
+	struct cfs_fh *fh = NULL;
+
+	/* TODO:Temp_FH_op - to be removed
+	 * Should get rid of creating and destroying FH operation in this
+	 * API when caller pass the valid FH instead of inode number
+	 */
+	RC_WRAP_LABEL(rc, out, cfs_fh_from_ino, cfs_fs, ino, &fh);
+	RC_WRAP_LABEL(rc, out, cfs_destroy_orphaned_file2, fh);
+
+out:
+	if (fh != NULL) {
+		cfs_fh_destroy(fh);
+	}
+	log_trace("inode=%llu rc=%d", *ino, rc);
 	return rc;
 }
 
@@ -828,48 +847,81 @@ out:
 	return rc;
 }
 
-int cfs_detach(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
-	       const cfs_ino_t *parent, const cfs_ino_t *obj,
-	       const char *name)
+static int cfs_detach2(struct cfs_fh *parent_fh, struct cfs_fh *child_fh,
+                       const cfs_cred_t *cred, const char *name)
 {
 	int rc;
 	str256_t k_name;
-	struct kvstore *kvstor = kvstore_get();
 	struct kvs_idx index;
-	struct kvnode node = KVNODE_INIT_EMTPY;
-	struct kvnode pnode = KVNODE_INIT_EMTPY;
+	struct kvstore *kvstor = kvstore_get();
+	struct cfs_fs *cfs_fs = NULL;
+	struct stat *parent_stat = NULL;
+	struct stat *child_stat = NULL;
+	node_id_t *pnode_id = NULL;
 
-	dassert(kvstor != NULL);
+	dassert(kvstor && parent_fh && cred && child_fh && name);
 
+	cfs_fs = cfs_fs_from_fh(parent_fh);
 	index = cfs_fs->kvtree->index;
-
-	str256_from_cstr(k_name, name, strlen(name));
-	RC_WRAP_LABEL(rc, out, cfs_access, cfs_fs, (cfs_cred_t *) cred,
-		      (cfs_ino_t *) parent, CFS_ACCESS_DELETE_ENTITY);
-
 	kvs_begin_transaction(kvstor, &index);
 
-	node_id_t pnode_id;
+	parent_stat = cfs_fh_stat(parent_fh);
+	child_stat = cfs_fh_stat(child_fh);
 
-	ino_to_node_id(parent, &pnode_id);
-	RC_WRAP_LABEL(rc, out, kvtree_detach, cfs_fs->kvtree, &pnode_id,
+	RC_WRAP_LABEL(rc, out, cfs_access_check, cred, parent_stat,
+		      CFS_ACCESS_DELETE_ENTITY);
+
+	pnode_id = cfs_node_id_from_fh(parent_fh);
+	str256_from_cstr(k_name, name, strlen(name));
+	RC_WRAP_LABEL(rc, out, kvtree_detach, cfs_fs->kvtree, pnode_id,
 		      &k_name);
 
-	RC_WRAP_LABEL(rc, out, cfs_kvnode_load, &node, cfs_fs->kvtree, obj);
-	RC_WRAP_LABEL(rc, out, cfs_update_stat, &node,
+	RC_WRAP_LABEL(rc, out, cfs_amend_stat, child_stat,
 		      STAT_CTIME_SET|STAT_DECR_LINK);
 
-	RC_WRAP_LABEL(rc, out, cfs_kvnode_load, &pnode, cfs_fs->kvtree, parent);
-	RC_WRAP_LABEL(rc, out, cfs_update_stat, &pnode,
+	RC_WRAP_LABEL(rc, out, cfs_amend_stat, parent_stat,
 		      STAT_CTIME_SET|STAT_MTIME_SET);
 
 	kvs_end_transaction(kvstor, &index);
 
 out:
-	kvnode_fini(&pnode);
-	kvnode_fini(&node);
 	if (rc != 0) {
 		kvs_discard_transaction(kvstor, &index);
 	}
+
+	log_trace("parent_ino=%llu name=%s child_ino=%llu rc=%d",
+		  (unsigned long long int)parent_stat->st_ino, name,
+		  (unsigned long long int)child_stat->st_ino, rc);
+
+	return rc;
+}
+
+int cfs_detach(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
+               const cfs_ino_t *parent_ino, const cfs_ino_t *child_ino,
+               const char *name)
+{
+	int rc;
+	struct cfs_fh *parent_fh = NULL;
+	struct cfs_fh *child_fh = NULL;
+
+	/* TODO:Temp_FH_op - to be removed
+	 * Should get rid of creating and destroying FH operation in this
+	 * API when caller pass the valid FH instead of inode number
+	 */
+	RC_WRAP_LABEL(rc, out, cfs_fh_from_ino, cfs_fs, parent_ino, &parent_fh);
+	RC_WRAP_LABEL(rc, out, cfs_fh_from_ino, cfs_fs, child_ino, &child_fh);
+	RC_WRAP_LABEL(rc, out, cfs_detach2, parent_fh, child_fh, cred, name);
+
+out:
+	if (parent_fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(parent_fh);
+	}
+
+	if (child_fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(child_fh);
+	}
+
+	log_trace("parent_ino=%llu name=%s child_ino=%llu rc=%d",
+		  *parent_ino, name, *child_ino, rc);
 	return rc;
 }

--- a/src/include/cortxfs_fh.h
+++ b/src/include/cortxfs_fh.h
@@ -115,6 +115,7 @@
 #define CFS_FH_H_
 
 #include "cortxfs.h"
+#include "nsal.h"
 struct cfs_fh;
 
 /* The example of CORTXFS API described below allocates new file handles in
@@ -168,6 +169,12 @@ void cfs_fh_destroy(struct cfs_fh *fh);
  */
 void cfs_fh_destroy_and_dump_stat(struct cfs_fh *fh);
 
+/* Get a pointer to node_id of a File Handle.
+ * @param[in] fh - Any initialized FH.
+ * @return Pointer to internal buffer which holds node_id number.
+ */
+node_id_t *cfs_node_id_from_fh(struct cfs_fh *fh);
+
 /* Get a pointer to inode numuber of a File Handle.
  * @param[in] fh - Any initialized FH.
  * @return Pointer to internal buffer which holds inode number.
@@ -179,6 +186,12 @@ cfs_ino_t *cfs_fh_ino(struct cfs_fh *fh);
  * @return Pointer to FS context.
  */
 struct cfs_fs *cfs_fs_from_fh(const struct cfs_fh *fh);
+
+/* Get a pointer to kvnode hold by a File Handle.
+ * @param[in] fh - Any initialized FH.
+ * @return Pointer to internal buffer which holds struct kvnode.
+ */
+struct kvnode *cfs_kvnode_from_fh(struct cfs_fh *fh);
 
 /* Get a pointer to attributes (stat) of a File Handle.
  * @param[in] fh - Any initialized FH.


### PR DESCRIPTION
# Cortx-fs Change Summary

## Problem Statement

_[EOS-9005](https://jts.seagate.com/browse/EOS-9005):_
_EOS-NFS: Update cfs_detach, and cfs_destroy_orphaned_file_

## Problem Description

_With recent changes in FH we decided to supply a valid FH to all of the API in cortxfs wherever it is required, so that task was divided in further small task and as a part of that we have to modify cfs_detach and cfs_destroy_orphaned_file to use FH and optimize whatever was possible_

## Solution Overview

_As cfs_detach and cfs_destroy_orphaned_file were used by cortxfs API and FSAL code also so it was not directly possible to modify the signature of both of these API to pass FH as input parameter because we are not yet in a stage where we can pass a FH from FSAL code as it will have stale data. So with this limitation on both of these APIs I have created a temporary API where input will be FH and original API signature will remain same. So going forward the temporary API directly can be used by other APIs in cortxfs. Once all the caller of cfs_detach and cfs_destroy_orphaned_file has valid FH we can remove the temporary APIs_

## Unit Test Cases
_All UTs are passing_
_Able to create FS, mount FS and do basic I/O on that_
_Cthon is passing_
_Following steps are working as expected and output of this step has been added here as a testing summary_

1. sudo mount -o vers=4.0 127.0.0.1:/fs1 /tmp/mnt_dir/
2. cd /tmp/mnt_dir/
3. echo `date` > "file1"
4. mkdir dir1
5. for i in {1..5} ; do ln file1 dir1/link$i ; done
6. stat file1

## Note: 
_I have mounted /var/motr separately in order to avoid /var/motr is getting 100% full_



## Testing
<details>
  <summary>Click here to see the test execution output</summary>

```
# touch file1
[root@ssc-vm-0115: dir1 ]#
# ls
file1
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 0               Blocks: 0          IO Block: 1048576 regular empty file
Device: 2ch/44d Inode: 7           Links: 1
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:40:35.362265817 -0600
Change: 2020-10-11 22:40:35.362267000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# mkdir dir1
[root@ssc-vm-0115: dir1 ]#
# ls
dir1  file1
[root@ssc-vm-0115: dir1 ]#
# echo `date` > file1
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 1
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:41:01.899546000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# for i in {1..5} ; do ln file1 dir1/link$i ; done
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 6
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:41:17.903080000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# rm dir1/link1
rm: remove regular file ‘dir1/link1’? y
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 5
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:41:49.540530000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# rm dir1/link2
rm: remove regular file ‘dir1/link2’? y
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 4
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:42:01.381457000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# ls
dir1  file1
[root@ssc-vm-0115: dir1 ]#
# cd dir1/
[root@ssc-vm-0115: dir1 ]#
# ls
link3  link4  link5
[root@ssc-vm-0115: dir1 ]#
# ls -lsi
total 2
7 1 -rw-r--r--. 4 root root 29 Oct 11 22:41 link3
7 1 -rw-r--r--. 4 root root 29 Oct 11 22:41 link4
7 1 -rw-r--r--. 4 root root 29 Oct 11 22:41 link5
[root@ssc-vm-0115: dir1 ]#
# cd ../
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 4
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:42:01.381457000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# rm dir1/link
link3  link4  link5
[root@ssc-vm-0115: dir1 ]#
# rm dir1/link3
rm: remove regular file ‘dir1/link3’? y
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 3
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:42:43.792214000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# rm dir1/link4
rm: remove regular file ‘dir1/link4’? y
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 2
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:42:53.528294000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# rm dir1/link5
rm: remove regular file ‘dir1/link5’? y
[root@ssc-vm-0115: dir1 ]#
# stat file1
  File: ‘file1’
  Size: 29              Blocks: 1          IO Block: 1048576 regular file
Device: 2ch/44d Inode: 7           Links: 1
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:nfs_t:s0
Access: 2020-10-11 22:40:35.362265739 -0600
Modify: 2020-10-11 22:41:01.899546000 -0600
Change: 2020-10-11 22:43:01.791946000 -0600
 Birth: -
[root@ssc-vm-0115: dir1 ]#
# cat file1
Sun Oct 11 22:41:01 MDT 2020
```
  
</details>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [x] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _As mentioned in description all UTs and cthon is passing._
- [x] **Documentation:** _This patch, merge request, Jira ticket [EOS-9005](https://jts.seagate.com/browse/EOS-9005) have up to date description_