### PR TITLE
EOS-14314:Cleanup unused data server parameter from cortxfscli

### DIFF
--- a/src/cortxfscli/cortxfscli.py
+++ b/src/cortxfscli/cortxfscli.py
@@ -71,8 +71,7 @@ cortxfscli_default_validation_rules = """{
 			"Squash" : {"set" : "no_root_squash,root_squash"},
 			"access_type" : {"set" : "RW,R,W,None"},
 			"protocols" : {"set" : "4,4.1"},
-			"pnfs_enabled" : {"set" : "true,false"},
-			"data_server" : {"regex" : "[^A-Za-z0-9.*/]", "limit" : "16"}
+			"pnfs_enabled" : {"set" : "true,false"}
 	},
 
 	"smb" : {

--- a/src/cortxfscli/cortxfscli_validation_rules.json
+++ b/src/cortxfscli/cortxfscli_validation_rules.json
@@ -9,8 +9,7 @@
             "Squash" : {"set" : "no_root_squash,root_squash"},
             "access_type" : {"set" : "RW,R,W,None"},
             "protocols" : {"set" : "4,4.1"},
-            "pnfs_enabled" : {"set" : "true,false"},
-            "data_server" : {"regex" : "[^A-Za-z0-9.*/]", "limit" : "16"}
+            "pnfs_enabled" : {"set" : "true,false"}
 	},
 
         "smb" : {


### PR DESCRIPTION
# EOS-14314 : Cleanup unused pNFS(data server) parameters from cortxfscli script.

## Solution Overview
Change description:
1)Data server parameter continued to get parsed when endpoints are created using cortxfscli script.
This parameter is unused in the code and can be removed.

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** Single node changes are unit tested_

##  Unit test (on LABVM):
1)Compiled the code and reinstalled the RPM
2)Ran the cortxfscli script with the following parameters
**cortxfscli endpoint create fs1 proto=nfs,secType=sys,Filesystem_id=192.1,client=1,clients=*,Squash=no_root_squash,access_type=RW,protocols=4,pnfs_enabled=false**
**This did not give any error.**

cortxfscli endpoint create fs1 proto=nfs,secType=sys,Filesystem_id=192.1,client=1,clients=*,Squash=no_root_squash,access_type=RW,protocols=4,pnfs_enabled=false,**data_server=10.230.242.6**
Using embedded validation rules
Traceback (most recent call last):
  File "/bin/cortxfscli", line 313, in get_command
    command.validate_args_payload(args)
  File "/bin/cortxfscli", line 250, in validate_args_payload
    validate_inp_config_params(cortxfscli_config_rules, args.args[1])
  File "/bin/cortxfscli", line 132, in validate_inp_config_params
    conf_vals = conf_params[inp_key]
**When data server is specified error should be seen**


