### PR TITLE
EOS-13992: ADDB tracepoints for directory operations

### DIFF
--- a/src/cortxfs/cortxfs_fh.c
+++ b/src/cortxfs/cortxfs_fh.c
@@ -29,6 +29,7 @@
 #include <common.h> /* unlikely */
 #include <common/log.h> /* log_err() */
 #include "kvtree.h" /* kvtree_lookup() */
+#include "operation.h" /* perf tracepoints */
 
 /**
  * A unique key to be used in containers (maps, sets).
@@ -159,8 +160,9 @@ out:
 	return rc;
 }
 
-int cfs_fh_lookup(const cfs_cred_t *cred, struct cfs_fh *parent_fh,
-                  const char *name, struct cfs_fh **fh)
+static inline int __cfs_fh_lookup(const cfs_cred_t *cred,
+				  struct cfs_fh *parent_fh,
+				  const char *name, struct cfs_fh **fh)
 {
 	int rc;
 	str256_t kname;
@@ -212,6 +214,18 @@ out:
 	if (newfh) {
 		cfs_fh_destroy(newfh);
 	}
+	return rc;
+}
+
+int cfs_fh_lookup(const cfs_cred_t *cred, struct cfs_fh *parent_fh,
+                const char *name, struct cfs_fh **fh)
+{
+	int rc;
+
+	perfc_trace_inii(PFT_CFS_LOOKUP, PEM_CFS_TO_NFS);
+	rc = __cfs_fh_lookup(cred, parent_fh, name, fh);
+	perfc_trace_finii(PERFC_TLS_POP_VERIFY);
+
 	return rc;
 }
 

--- a/src/cortxfs/cortxfs_ops.c
+++ b/src/cortxfs/cortxfs_ops.c
@@ -256,11 +256,9 @@ bool cfs_readdir_cb(void *cb_ctx, const char *name, const struct kvnode *node)
 	return retval;
 }
 
-int cfs_readdir(struct cfs_fs *cfs_fs,
-		const cfs_cred_t *cred,
-		const cfs_ino_t *dir_ino,
-		cfs_readdir_cb_t cb,
-		void *cb_ctx)
+static inline int __cfs_readdir(struct cfs_fs *cfs_fs,
+		const cfs_cred_t *cred, const cfs_ino_t *dir_ino,
+		cfs_readdir_cb_t cb, void *cb_ctx)
 {
 	int rc;
 	struct cfs_readdir_ctx cb_info = { .cb = cb, .ctx = cb_ctx};
@@ -281,8 +279,22 @@ out:
 	return rc;
 }
 
-int cfs_mkdir(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent_ino,
-              char *name, mode_t mode, cfs_ino_t *newdir_ino)
+int cfs_readdir(struct cfs_fs *cfs_fs,
+		const cfs_cred_t *cred, const cfs_ino_t *dir_ino,
+		cfs_readdir_cb_t cb, void *cb_ctx)
+{
+	int rc;
+
+	perfc_trace_inii(PFT_CFS_READDIR, PEM_CFS_TO_NFS);
+	rc = __cfs_readdir(cfs_fs, cred, dir_ino, cb, cb_ctx);
+	perfc_trace_finii(PERFC_TLS_POP_VERIFY);
+
+	return rc;
+}
+
+static inline int __cfs_mkdir(struct cfs_fs *cfs_fs, cfs_cred_t *cred,
+			cfs_ino_t *parent, char *name,
+			mode_t mode, cfs_ino_t *newdir)
 {
 	int rc;
 	dstore_oid_t oid;
@@ -290,13 +302,13 @@ int cfs_mkdir(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent_ino,
 	struct cfs_fh *parent_fh = NULL;
 	struct stat *parent_stat = NULL;
 
-	dassert(dstore && cfs_fs && cred && parent_ino && name && newdir_ino);
+	dassert(dstore && cfs_fs && cred && parent && name && newdir);
 
 	/* TODO:Temp_FH_op - to be removed
 	 * Should get rid of creating and destroying FH operation in this
 	 * API when caller pass the valid FH instead of inode number
 	 */
-	RC_WRAP_LABEL(rc, out, cfs_fh_from_ino, cfs_fs, parent_ino, &parent_fh);
+	RC_WRAP_LABEL(rc, out, cfs_fh_from_ino, cfs_fs, parent, &parent_fh);
 
 	parent_stat = cfs_fh_stat(parent_fh);
 
@@ -304,13 +316,13 @@ int cfs_mkdir(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent_ino,
 		      CFS_ACCESS_WRITE);
 
 	RC_WRAP_LABEL(rc, out, cfs_create_entry, parent_fh, cred, name, NULL,
-		      mode, newdir_ino, CFS_FT_DIR);
+		      mode, newdir, CFS_FT_DIR);
 
 	/* Get a new unique oid */
 	RC_WRAP_LABEL(rc, out, dstore_get_new_objid, dstore, &oid);
 
 	/* Set the ino-oid mapping for this directory in kvs.*/
-	RC_WRAP_LABEL(rc, out, cfs_set_ino_oid, cfs_fs, newdir_ino, &oid);
+	RC_WRAP_LABEL(rc, out, cfs_set_ino_oid, cfs_fs, newdir, &oid);
 
 out:
 	if (parent_fh != NULL) {
@@ -318,7 +330,19 @@ out:
 	}
 
 	log_trace("parent_ino=%llu name=%s newdir_ino=%llu mode=0x%X rc=%d",
-		   *parent_ino, name, *newdir_ino, mode, rc);
+		   *parent, name, *newdir, mode, rc);
+	return rc;
+}
+
+int cfs_mkdir(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent,
+	      char *name, mode_t mode, cfs_ino_t *newdir)
+{
+	int rc;
+
+	perfc_trace_inii(PFT_CFS_MKDIR, PEM_CFS_TO_NFS);
+	rc = __cfs_mkdir(cfs_fs, cred, parent, name, mode, newdir);
+	perfc_trace_finii(PERFC_TLS_POP_VERIFY);
+
 	return rc;
 }
 
@@ -730,7 +754,8 @@ out:
 	return rc;
 }
 
-int cfs_rmdir(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent, char *name)
+static inline int __cfs_rmdir(struct cfs_fs *cfs_fs, cfs_cred_t *cred,
+			cfs_ino_t *parent, char *name)
 {
 	int rc;
 	cfs_ino_t ino = 0LL;
@@ -806,6 +831,18 @@ aborted:
 out:
 	log_debug("EXIT cfs_fs=%p ino=%llu name=%s rc=%d", cfs_fs,
 		   ino, name, rc);
+	return rc;
+}
+
+int cfs_rmdir(struct cfs_fs *cfs_fs, cfs_cred_t *cred,
+		cfs_ino_t *parent, char *name)
+{
+	int rc;
+
+	perfc_trace_inii(PFT_CFS_RMDIR, PEM_CFS_TO_NFS);
+	rc = __cfs_rmdir(cfs_fs, cred, parent, name);
+	perfc_trace_finii(PERFC_TLS_POP_VERIFY);
+
 	return rc;
 }
 


### PR DESCRIPTION
# CORTXFS Change Summary

## Problem Statement
_[EOS-13992](https://jts.seagate.com/browse/EOS-13992):_
_ADDB Tracepoints-Directory Operations_

## Problem Description
_Add ADDB tracepoints for Directory operations_

## Solution Overview
_Directory operations include, directory creation (mkdir), directory removal (rmdir), read the directory contents (readdir) and lookup a specific entry in directory (lookup). ADDB tracepoint added for function entry and points. This provides information on how much time the function / code snippet takes._

### Companion PRs
https://github.com/Seagate/cortx-utils/pull/48
https://github.com/Seagate/cortx-fs-ganesha/pull/40
https://github.com/Seagate/cortx-nsal/pull/23

## Unit Test Cases
_No new test cases added_

## Testing
<details>
  <summary>Click here to see the test execution output</summary>

```
[root@ssc-vm-c-0689 cortx-posix]# ./scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 1
Tests passed = 1
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0


```

</details>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _None_
- [ ] **Code review:** _In progress_
- [X] **Sanity Testing:** _Done as mentioned in testing above_
- [X] **Documentation:** _None_