### PR TITLE
[Github Action] Issue triage

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,13 @@
+name: Issue triage
+on:
+  issues:
+    types: [opened]
+jobs:
+  build:
+    name: Triage
+    runs-on: ubuntu-16.04
+    steps:
+    - uses: Logerfo/triage-action@0.0.2
+      with:
+        github-token: ${{ secrets.ACCESS_TOKEN }}
+        label: "needs-triage"


### PR DESCRIPTION
Signed-off-by: Gaurav Chaudhari <gaurav.chaudhari@seagate.com>

## Why Triage?
Triage is an important part of open source. It can be difficult to keep up with the issues as the size of a project grows, the demands placed on the maintainers grow. This means they are forced to choose between spending enormous amounts of time reviewing each GitHub issue, only skimming over issues, or worse, ignoring issues.

## How triage action would be helpful?
Triage action can help an open-source project by labeling newly opened issues as `needs-triage`. So, maintainers could easily filter out all unattended/missed issues and label them appropriately in triage meetings. Now, it would be easy for a specific group of maintainers to filter out issues of their expertise/interest and start reviewing it in a timely manner.