### PR TITLE
EOS-14498 : Added Swagger document to the build process

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -164,6 +164,17 @@ cortxfs_make() {
         exit 1;
     fi
 
+    if [ -f "$CORTXFS_SRC/management/REST_doc.html" ]; then
+	    echo "Deleting Swagger Documentation"
+	    rm "$CORTXFS_SRC/management/REST_doc.html"
+    fi
+
+    sudo pip3 install PyYaml
+    echo "Generating Swagger Documentation"
+    python3 "$CORTXFS_SRC/management/swagger-yaml-to-html.py" < \
+    "$CORTXFS_SRC/management/openapi.yaml" > \
+    "$CORTXFS_SRC/management/REST_doc.html"
+
     cd "$CORTXFS_BUILD"
     make "$@"
     cd -

--- a/src/cortx-fs.spec-in.cmake
+++ b/src/cortx-fs.spec-in.cmake
@@ -71,6 +71,8 @@ mkdir -p %{buildroot}%{_libdir}/pkgconfig
 install -m 644 include/*.h  %{buildroot}%{_cortxfs_include_dir}
 install -m 755 lib%{_cortxfs_lib}.so %{buildroot}%{_cortxfs_lib_dir}
 install -m 644 cortxfs.conf %{buildroot}%{_cortxfs_conf_dir}
+install -m 644 management/REST_doc.html \
+%{buildroot}%{_cortxfs_include_dir}
 install -m 755 cortxfscli/cortxfscli.py %{buildroot}%{_cortxfs_bin_dir}/cortxfscli
 install -m 644 %{_cortxfs_lib}.pc  %{buildroot}%{_libdir}/pkgconfig
 ln -s %{_cortxfs_lib_dir}/lib%{_cortxfs_lib}.so %{buildroot}%{_libdir}/lib%{_cortxfs_lib}.so
@@ -89,11 +91,11 @@ rm -rf $RPM_BUILD_ROOT
 %{_cortxfs_bin_dir}/cortxfscli
 %{_bindir}/cortxfscli
 %{_cortxfs_log_dir}
-
 %files devel
 %defattr(-,root,root)
 %{_libdir}/pkgconfig/%{_cortxfs_lib}.pc
 %{_cortxfs_include_dir}/*.h
+%{_cortxfs_include_dir}/REST_doc.html
 
 %changelog
 * Thu Feb 6 2020 Seagate 1.0.1

--- a/src/management/swagger-yaml-to-html.py
+++ b/src/management/swagger-yaml-to-html.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+#
+#  Copyright 2017 Otto Seiskari
+#  Licensed under the Apache License, Version 2.0.
+#  See http://www.apache.org/licenses/LICENSE-2.0 for the full text.
+#
+#  This file is based on
+#  https://github.com/swagger-api/swagger-ui/blob/4f1772f6544699bc748299bd65f7ae2112777abc/dist/index.html
+#  (Copyright 2017 SmartBear Software, Licensed under Apache 2.0)
+#
+"""
+Usage:
+
+    python swagger-yaml-to-html.py < /path/to/api.yaml > doc.html
+
+"""
+import yaml, json, sys
+
+TEMPLATE = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Swagger UI</title>
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
+  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.24.2/swagger-ui.css" >
+  <style>
+    html
+    {
+      box-sizing: border-box;
+      overflow: -moz-scrollbars-vertical;
+      overflow-y: scroll;
+    }
+    *,
+    *:before,
+    *:after
+    {
+      box-sizing: inherit;
+    }
+
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+  </style>
+</head>
+<body>
+
+<div id="swagger-ui"></div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.24.2/swagger-ui-bundle.js"> </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.24.2/swagger-ui-standalone-preset.js"> </script>
+<script>
+window.onload = function() {
+
+  var spec = %s;
+
+  // Build a system
+  const ui = SwaggerUIBundle({
+    spec: spec,
+    dom_id: '#swagger-ui',
+    deepLinking: true,
+    presets: [
+      SwaggerUIBundle.presets.apis,
+      SwaggerUIStandalonePreset
+    ],
+    plugins: [
+      SwaggerUIBundle.plugins.DownloadUrl
+    ],
+    layout: "StandaloneLayout"
+  })
+
+  window.ui = ui
+}
+</script>
+</body>
+
+</html>
+"""
+
+spec = yaml.load(sys.stdin, Loader=yaml.FullLoader)
+sys.stdout.write(TEMPLATE % json.dumps(spec))


### PR DESCRIPTION
Added swagger-yaml-to-html.py to generate html document 
from a yaml file.
Made changes to build.sh so that a html document is generated
when build.sh is called.
Made changes to cortx-fs.spec-in.cmake so that html file is
included in devel package

Signed-off-by: Deepak Mahale <deepak.mahale@seagate.com>

Pre-requisite : Python3 should be installed on the system.

We are including a 3rd party script, so need approval.

Unit Tests :

> bash-4.2$ sudo ./scripts/test.sh
> Configuration Completed
> Clean indexes prepared
> NSAL Unit tests
> NS Tests
> Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
> Total tests  = 5
> Tests passed = 5
> Tests failed = 0
> 
> Iterator test
> Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
> Total tests  = 2
> Tests passed = 2
> Tests failed = 0
> 
> KVTree test
> Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
> Total tests  = 17
> Tests passed = 17
> Tests failed = 0
> 
> Global KVS Tests
> Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
> Total tests  = 4
> Tests passed = 4
> Tests failed = 0
> 
> CORTXFS Unit tests
> Endpoint ops Tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
> Total tests  = 4
> Tests passed = 4
> Tests failed = 0
> 
> FS Tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
> Total tests  = 3
> Tests passed = 3
> Tests failed = 0
> 
> Directory tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
> Total tests  = 14
> Tests passed = 14
> Tests failed = 0
> 
> File creation tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
> Total tests  = 4
> Tests passed = 4
> Tests failed = 0
> 
> Link Tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
> Total tests  = 6
> Tests passed = 6
> Tests failed = 0
> 
> Rename tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
> Total tests  = 3
> Tests passed = 3
> Tests failed = 0
> 
> Attribute Tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
> Total tests  = 5
> Tests passed = 5
> Tests failed = 0
> 
> Xattr file Tests
> Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
> Total tests  = 9
> Tests passed = 8
> Tests failed = 1
> 
> Xattr dir Tests
> Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
> Total tests  = 9
> Tests passed = 8
> Tests failed = 1
> 
> IO tests
> Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
> Total tests  = 7
> Tests passed = 7
> Tests failed = 0
> 
> DSAL Unit tests
> Dsal basic test
> Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
> Total tests  = 11
> Tests passed = 11
> Tests failed = 0
> 
> Dsal IO test
> Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
> Total tests  = 1
> Tests passed = 1
> Tests failed = 0
> 
> Dsal space stats test
> Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
> Total tests  = 2
> Tests passed = 2
> Tests failed = 0