### PR TITLE
EOS-13989: Modified cfs_rename, cfs_rmdir and cfs_rename_tree_link AP…

### DIFF
--- a/src/include/cortxfs.h
+++ b/src/include/cortxfs.h
@@ -197,14 +197,20 @@ int cfs_create_entry(struct cfs_fh *parent_fh, cfs_cred_t *cred, char *name,
                      enum cfs_file_type type);
 
 /******************************************************************************/
-/** Change the name of a link between a parent node and a child node without
+/**  */
+/**
+ * Change the name of a link between a parent node and a child node without
  * modifying the link itself.
+
+ * @param parent_fh - Parent file handle
+ * @param child_fh - Child file handle
+ * @param old_name - Old file name
+ * @param new_name - New file name to be replaced with for old file
+ *
+ * @return 0 if successful, a negative "-errno" value in case of failure
  */
-int cfs_tree_rename_link(struct cfs_fs *cfs_fs,
-			 const cfs_ino_t *parent_ino,
-			 const cfs_ino_t *ino,
-			 const str256_t *old_name,
-			 const str256_t *new_name);
+int cfs_tree_rename_link(struct cfs_fh *parent_fh, struct cfs_fh *child_fh,
+                         const str256_t *old_name, const str256_t *new_name);
 
 /******************************************************************************/
 /* CORTXFS internal data types */


### PR DESCRIPTION
# Cortx-fs Change Summary

## Problem Statement

_[EOS-13989](https://jts.seagate.com/browse/EOS-13989):_
_EOS-NFS: Update cfs_rename, cfs_rmdir, cfs_rename_tree_link to use FH_

## Problem Description

_With recent changes in FH we decided to supply a valid FH to all of the API in cortxfs wherever it is required, so that task was divided in further small task and as a part of that we have to modify cfs_rename, cfs_rmdir and cfs_rename_link_tree API to use FH and optimize whatever was possible_

## Solution Overview

_Have modified cfs_rename, cfs_rmdir and cfs_rename_link_tree API to construct the FH based on given inode as input param and use it for further logic inside this API_

## Unit Test Cases

- _All UTs are passing - attached the log here_
- _Cthon is passing  - attached the log here_
- _Able to create FS, mount FS and do basic I/O on that_
- _Able to validated following test case manually after mounting FS and those are working as expected_

### _Rename with existing file to another directory is not working - overwriting case_
      
  1. _mounted fs to /mnt/dir1_
  2. _mkdir testdir1_
  3. _mkdir testdir2_
  4. _touch testdir1/file1.txt_
  5. _touch testdir2/file2.txt_
  6. _echo "THIS IS FILE1" > testdir1/file1.txt_
  7. _echo "THIS IS FILE2" > testdir2/file2.txt_
  8. _mv testdir1/file1.txt testdir2/file2.txt_

### _Source parent directory stats are not updated correctly - Hard link count issue_

   1. _Install the RPMs, do setup and mount the File System._
   2. _Go to mounted directory._
   3. _mkdir -p a/b_
   4. _mkdir c_
   5. _stat a (Here Links should be 3 as it has a child directory)_
   6. _stat b (Here Links should be 2 as it is empty directory)_
   7. _mv a/b c_
   8. _stat a_

## Note: 
_I have mounted /var/motr separately in order to avoid /var/motr is getting 100% full_



## Testing
<details>
  <summary>Click here to see the test execution output</summary>

```
Second run after review addressing

# rtest
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests                                                                                         [49/875]
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests                                                                                               [18/875]
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 8
Tests failed = 1

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 8
Tests failed = 1

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0




# sudo /opt/seagate/cortx/fs-ganesha/test/run_cthon.sh -m /mnt/dir1 -p fs1 -a
sh ./runtests  -a -t /mnt/dir1/ssc-vm-0115.test

Starting BASIC tests: test directory /mnt/dir1/ssc-vm-0115.test (arg: -t)

./test1: File and directory creation test
        created 4 files 2 directories 2 levels deep in 0.37 seconds
        ./test1 ok.

./test2: File and directory removal test
        removed 4 files 2 directories 2 levels deep in 0.25 seconds
        ./test2 ok.

./test3: lookups across mount point
        500 getcwd and stat calls in 0.0  seconds
        ./test3 ok.

./test4: setattr, getattr, and lookup                                                                    [504/1478]
        1000 chmods and stats on 10 files in 12.74 seconds
        ./test4 ok.
./test4a: getattr and lookup
        1000 stats on 10 files in 0.1  seconds
        ./test4a ok.

TESTARG=-t
./test6: readdir
        7500 entries read, 120 files in 52.20 seconds
        ./test6 ok.

./test7: link and rename
        200 renames and links on 10 files in 14.33 seconds
        ./test7 ok.

./test8: symlink and readlink
        400 symlinks and readlinks on 10 files in 13.9  seconds
        ./test8 ok.

./test9: statfs
        1500 statfs calls in 3.7  seconds
        ./test9 ok.

Congratulations, you passed the basic tests!

GENERAL TESTS: directory /mnt/dir1/ssc-vm-0115.test
if test ! -x runtests; then chmod a+x runtests; fi
cd /mnt/dir1/ssc-vm-0115.test; rm -f Makefile runtests runtests.wrk *.sh *.c mkdummy rmdummy nroff.in makefile.tst
cp Makefile runtests runtests.wrk *.sh *.c mkdummy rmdummy nroff.in makefile.tst /mnt/dir1/ssc-vm-0115.test

Small Compile                                                                                            [473/1478]
smcomp.time
        0.1 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Tbl
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Nroff
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Large Compile
        0.1 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Four simultaneous large compiles
        0.2 (0.0) real  0.1 (0.0) user  0.0 (0.0) sys

Makefile
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

General tests complete

SPECIAL TESTS: directory /mnt/dir1/ssc-vm-0115.test
cd /mnt/dir1/ssc-vm-0115.test; rm -f runtests runtests.wrk READWIN.txt Makefile op_unlk op_ren op_chmod dupreq excl
test negseek rename holey truncate nfsidem nstat stat stat2 touchn fstat rewind telldir bigfile bigfile2 freesp
cp runtests runtests.wrk READWIN.txt Makefile op_unlk op_ren op_chmod dupreq excltest negseek rename holey truncate
 nfsidem nstat stat stat2 touchn fstat rewind telldir bigfile bigfile2 freesp /mnt/dir1/ssc-vm-0115.test

check for proper open/unlink operation                                                                   [446/1478]
nfsjunk files before unlink:
  -rw-rw-rw-. 1 root root 0 Oct 29 00:24 ./nfst8A7pp
./nfst8A7pp open; unlink ret = 0
nfsjunk files after unlink:
  ls: cannot access ./nfst8A7pp: No such file or directory
data compare ok
nfsjunk files after close:
  ls: cannot access ./nfst8A7pp: No such file or directory
test completed successfully.

check for proper open/rename operation
nfsjunk files before rename:
  -rwxrwxrwx. 1 root root 0 Oct 29 00:24 ./nfsaQ0Zf4D
  -rwxrwxrwx. 1 root root 0 Oct 29 00:24 ./nfsbugrQHm
./nfsbugrQHm open; rename ret = 0
nfsjunk files after rename:
  ls: cannot access ./nfsaQ0Zf4D: No such file or directory
  -rwxrwxrwx. 1 root root 0 Oct 29 00:24 ./nfsbugrQHm
data compare ok
nfsjunk files after close:
  ls: cannot access ./nfsaQ0Zf4D: No such file or directory
  ls: cannot access ./nfsbugrQHm: No such file or directory
test completed successfully.

check for proper open/chmod 0 operation
testfile before chmod:
  -rw-rw-rw-. 1 root root 0 Oct 29 00:24 ./nfskasUgZ
./nfskasUgZ open; chmod ret = 0
testfile after chmod:
  ----------. 1 root root 0 Oct 29 00:24 ./nfskasUgZ
data compare ok
testfile after write/read:                                                                               [414/1478]
  ----------. 1 root root 100 Oct 29 00:24 ./nfskasUgZ
test completed successfully.

check for lost reply on non-idempotent requests
100 tries

test exclusive create.

test negative seek, you should get: read: Invalid argument
or lseek: Invalid argument
lseek: Invalid argument

test rename

test truncate
truncate succeeded

test holey file support
Holey file test ok

second check for lost reply on non-idempotent requests
testing 50 idempotencies in directory "testdir"

test rewind support

test telldir cookies

test freesp and file size
fcntl(...F_FREESP...) not available on this platform.

write/read 30 MB file
                                                                                                         [382/1478]
write/read at 2GB, 4GB edges

Special tests complete

Starting LOCKING tests: test directory /mnt/dir1/ssc-vm-0115.test (arg: -t)

Testing native post-LFS locking

Creating parent/child synchronization pipes.

Test #1 - Test regions of an unlocked file.
        Parent: 1.1  - F_TEST  [               0,               1] PASSED.
        Parent: 1.2  - F_TEST  [               0,          ENDING] PASSED.
        Parent: 1.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Parent: 1.4  - F_TEST  [               1,               1] PASSED.
        Parent: 1.5  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 1.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Parent: 1.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Parent: 1.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Parent: 1.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.

Test #2 - Try to lock the whole file.                                                                    [360/1478]
        Parent: 2.0  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  2.1  - F_TEST  [               0,               1] PASSED.
        Child:  2.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  2.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Child:  2.4  - F_TEST  [               1,               1] PASSED.
        Child:  2.5  - F_TEST  [               1,          ENDING] PASSED.
        Child:  2.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Child:  2.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  2.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  2.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.
        Parent: 2.10 - F_ULOCK [               0,          ENDING] PASSED.

Test #3 - Try to lock just the 1st byte.
        Parent: 3.0  - F_TLOCK [               0,               1] PASSED.
        Child:  3.1  - F_TEST  [               0,               1] PASSED.
        Child:  3.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  3.3  - F_TEST  [               1,               1] PASSED.
        Child:  3.4  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 3.5  - F_ULOCK [               0,               1] PASSED.

Test #4 - Try to lock the 2nd byte, test around it.                                                      [339/1478]
        Parent: 4.0  - F_TLOCK [               1,               1] PASSED.
        Child:  4.1  - F_TEST  [               0,               1] PASSED.
        Child:  4.2  - F_TEST  [               0,               2] PASSED.
        Child:  4.3  - F_TEST  [               0,          ENDING] PASSED.
        Child:  4.4  - F_TEST  [               1,               1] PASSED.
        Child:  4.5  - F_TEST  [               1,               2] PASSED.
        Child:  4.6  - F_TEST  [               1,          ENDING] PASSED.
        Child:  4.7  - F_TEST  [               2,               1] PASSED.
        Child:  4.8  - F_TEST  [               2,               2] PASSED.
        Child:  4.9  - F_TEST  [               2,          ENDING] PASSED.
        Parent: 4.10 - F_ULOCK [               1,               1] PASSED.

Test #5 - Try to lock 1st and 2nd bytes, test around them.
        Parent: 5.0  - F_TLOCK [               0,               1] PASSED.
        Parent: 5.1  - F_TLOCK [               2,               1] PASSED.
        Child:  5.2  - F_TEST  [               0,               1] PASSED.
        Child:  5.3  - F_TEST  [               0,               2] PASSED.
        Child:  5.4  - F_TEST  [               0,          ENDING] PASSED.
        Child:  5.5  - F_TEST  [               1,               1] PASSED.
        Child:  5.6  - F_TEST  [               1,               2] PASSED.
        Child:  5.7  - F_TEST  [               1,          ENDING] PASSED.
        Child:  5.8  - F_TEST  [               2,               1] PASSED.
        Child:  5.9  - F_TEST  [               2,               2] PASSED.
        Child:  5.10 - F_TEST  [               2,          ENDING] PASSED.
        Child:  5.11 - F_TEST  [               3,               1] PASSED.
        Child:  5.12 - F_TEST  [               3,               2] PASSED.
        Child:  5.13 - F_TEST  [               3,          ENDING] PASSED.
        Parent: 5.14 - F_ULOCK [               0,               1] PASSED.
        Parent: 5.15 - F_ULOCK [               2,               1] PASSED.

Test #6 - Try to lock the MAXEOF byte.                                                                   [308/1478]
        Parent: 6.0  - F_TLOCK [7fffffffffffffff,               1] PASSED.
        Child:  6.1  - F_TEST  [7ffffffffffffffe,               1] PASSED.
        Child:  6.2  - F_TEST  [7ffffffffffffffe,               2] PASSED.
        Child:  6.3  - F_TEST  [7ffffffffffffffe,          ENDING] PASSED.
        Child:  6.4  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  6.5  - F_TEST  [7fffffffffffffff,               2] PASSED.
        Child:  6.6  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  6.7  - F_TEST  [8000000000000000,          ENDING] PASSED.
        Child:  6.8  - F_TEST  [8000000000000000,               1] PASSED.
        Child:  6.9  - F_TEST  [8000000000000000,7fffffffffffffff] PASSED.
        Child:  6.10 - F_TEST  [8000000000000000,8000000000000000] PASSED.
        Parent: 6.11 - F_ULOCK [7fffffffffffffff,               1] PASSED.

Test #7 - Test parent/child mutual exclusion.                                                            [294/1478]
        Parent: 7.0  - F_TLOCK [             ffc,               9] PASSED.
        Parent: Wrote 'aaaa eh' to testfile [ 4092, 7 ].
        Parent: Now free child to run, should block on lock.
        Parent: Check data in file to insure child blocked.
        Parent: Read 'aaaa eh' from testfile [ 4092, 7 ].
        Parent: 7.1  - COMPARE [             ffc,               7] PASSED.
        Parent: Now unlock region so child will unblock.
        Parent: 7.2  - F_ULOCK [             ffc,               9] PASSED.
        Child:  7.3  - F_LOCK  [             ffc,               9] PASSED.
        Child:  Write child's version of the data and release lock.
        Parent: Now try to regain lock, parent should block.
        Child:  Wrote 'bebebebeb' to testfile [ 4092, 9 ].
        Child:  7.4  - F_ULOCK [             ffc,               9] PASSED.
        Parent: 7.5  - F_LOCK  [             ffc,               9] PASSED.
        Parent: Check data in file to insure child unblocked.
        Parent: Read 'bebebebeb' from testfile [ 4092, 9 ].
        Parent: 7.6  - COMPARE [             ffc,               9] PASSED.
        Parent: 7.7  - F_ULOCK [             ffc,               9] PASSED.

Test #8 - Rate test performing lock/unlock cycles.
        Parent: Performed 1000 lock/unlock cycles in 3580 msecs. [33519 lpm].

Test #10 - Make sure a locked region is split properly.                                                  [271/1478]
        Parent: 10.0  - F_TLOCK [               0,               3] PASSED.
        Parent: 10.1  - F_ULOCK [               1,               1] PASSED.
        Child:  10.2  - F_TEST  [               0,               1] PASSED.
        Child:  10.3  - F_TEST  [               2,               1] PASSED.
        Child:  10.4  - F_TEST  [               3,          ENDING] PASSED.
        Child:  10.5  - F_TEST  [               1,               1] PASSED.
        Parent: 10.6  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.7  - F_ULOCK [               2,               1] PASSED.
        Child:  10.8  - F_TEST  [               0,               3] PASSED.
        Parent: 10.9  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.10 - F_TLOCK [               1,               3] PASSED.
        Parent: 10.11 - F_ULOCK [               2,               1] PASSED.
        Child:  10.12 - F_TEST  [               1,               1] PASSED.
        Child:  10.13 - F_TEST  [               3,               1] PASSED.
        Child:  10.14 - F_TEST  [               4,          ENDING] PASSED.
        Child:  10.15 - F_TEST  [               2,               1] PASSED.
        Child:  10.16 - F_TEST  [               0,               1] PASSED.

Test #11 - Make sure close() releases the process's locks.                                               [252/1478]
        Parent: 11.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Child:  11.1  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: 11.3  - F_TLOCK [              1d,             5b7] PASSED.
        Parent: 11.4  - F_TLOCK [            2000,              57] PASSED.
        Parent: Closed testfile.
        Child:  11.5  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.6  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.7  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 13, 16 ].
        Parent: Closed testfile.
        Child:  11.8  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.9  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.10 - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Truncated testfile.
        Parent: Closed testfile.
        Child:  11.11 - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.12 - F_ULOCK [               0,          ENDING] PASSED.

Test #12 - Signalled process should release locks.
        Child:  12.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Killed child process.
        Parent: 12.1  - F_TLOCK [               0,          ENDING] PASSED.

Test #13 - Check locking and mmap semantics.                                                             [224/1478]
        Parent: 13.0  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: 13.1  - mmap [               0,            1000] WARNING!
        Parent: **** Expected EAGAIN, returned success...
        Parent: 13.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: unmap testfile.
        Parent: 13.3  - mmap [               0,            1000] PASSED.
        Parent: 13.4  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: unmap testfile.

Test #14 - Rate test performing I/O on unlocked and locked file.
        Parent: File Unlocked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [466.73 +/- 1.68 KB/s].
        Parent: 14.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: File Locked                                                                              [200/1478]
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [415.25 +/- 2.64 KB/s].
        Parent: 14.1  - F_ULOCK [               0,          ENDING] PASSED.

Test #15 - Test 2nd open and I/O after lock and close.
        Parent: Second open succeeded.
        Parent: 15.0  - F_LOCK  [               0,          ENDING] PASSED.
        Parent: 15.1  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Parent: Wrote 'abcdefghij' to testfile [ 0, 11 ].
        Parent: Read 'abcdefghij' from testfile [ 0, 11 ].
        Parent: 15.2  - COMPARE [               0,               b] PASSED.

** PARENT pass 1 results: 49/49 pass, 1/1 warn, 0/0 fail (pass/total).

**  CHILD pass 1 results: 64/64 pass, 0/0 warn, 0/0 fail (pass/total).

Testing non-native 64 bit LFS locking

Creating parent/child synchronization pipes.

Test #1 - Test regions of an unlocked file.                                                              [169/1478]
        Parent: 1.1  - F_TEST  [               0,               1] PASSED.
        Parent: 1.2  - F_TEST  [               0,          ENDING] PASSED.
        Parent: 1.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Parent: 1.4  - F_TEST  [               1,               1] PASSED.
        Parent: 1.5  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 1.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Parent: 1.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Parent: 1.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Parent: 1.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.

Test #2 - Try to lock the whole file.
        Parent: 2.0  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  2.1  - F_TEST  [               0,               1] PASSED.
        Child:  2.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  2.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Child:  2.4  - F_TEST  [               1,               1] PASSED.
        Child:  2.5  - F_TEST  [               1,          ENDING] PASSED.
        Child:  2.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Child:  2.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  2.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  2.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.
        Parent: 2.10 - F_ULOCK [               0,          ENDING] PASSED.

Test #3 - Try to lock just the 1st byte.
        Parent: 3.0  - F_TLOCK [               0,               1] PASSED.
        Child:  3.1  - F_TEST  [               0,               1] PASSED.
        Child:  3.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  3.3  - F_TEST  [               1,               1] PASSED.
        Child:  3.4  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 3.5  - F_ULOCK [               0,               1] PASSED.

Test #4 - Try to lock the 2nd byte, test around it.                                                      [137/1478]
        Parent: 4.0  - F_TLOCK [               1,               1] PASSED.
        Child:  4.1  - F_TEST  [               0,               1] PASSED.
        Child:  4.2  - F_TEST  [               0,               2] PASSED.
        Child:  4.3  - F_TEST  [               0,          ENDING] PASSED.
        Child:  4.4  - F_TEST  [               1,               1] PASSED.
        Child:  4.5  - F_TEST  [               1,               2] PASSED.
        Child:  4.6  - F_TEST  [               1,          ENDING] PASSED.
        Child:  4.7  - F_TEST  [               2,               1] PASSED.
        Child:  4.8  - F_TEST  [               2,               2] PASSED.
        Child:  4.9  - F_TEST  [               2,          ENDING] PASSED.
        Parent: 4.10 - F_ULOCK [               1,               1] PASSED.

Test #5 - Try to lock 1st and 2nd bytes, test around them.
        Parent: 5.0  - F_TLOCK [               0,               1] PASSED.
        Parent: 5.1  - F_TLOCK [               2,               1] PASSED.
        Child:  5.2  - F_TEST  [               0,               1] PASSED.
        Child:  5.3  - F_TEST  [               0,               2] PASSED.
        Child:  5.4  - F_TEST  [               0,          ENDING] PASSED.
        Child:  5.5  - F_TEST  [               1,               1] PASSED.
        Child:  5.6  - F_TEST  [               1,               2] PASSED.
        Child:  5.7  - F_TEST  [               1,          ENDING] PASSED.
        Child:  5.8  - F_TEST  [               2,               1] PASSED.
        Child:  5.9  - F_TEST  [               2,               2] PASSED.
        Child:  5.10 - F_TEST  [               2,          ENDING] PASSED.
        Child:  5.11 - F_TEST  [               3,               1] PASSED.
        Child:  5.12 - F_TEST  [               3,               2] PASSED.
        Child:  5.13 - F_TEST  [               3,          ENDING] PASSED.
        Parent: 5.14 - F_ULOCK [               0,               1] PASSED.
        Parent: 5.15 - F_ULOCK [               2,               1] PASSED.

Test #6 - Try to lock the MAXEOF byte.                                                                   [106/1478]
        Parent: 6.0  - F_TLOCK [7fffffffffffffff,               1] PASSED.
        Child:  6.1  - F_TEST  [7ffffffffffffffe,               1] PASSED.
        Child:  6.2  - F_TEST  [7ffffffffffffffe,               2] PASSED.
        Child:  6.3  - F_TEST  [7ffffffffffffffe,          ENDING] PASSED.
        Child:  6.4  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  6.5  - F_TEST  [7fffffffffffffff,               2] PASSED.
        Child:  6.6  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  6.7  - F_TEST  [8000000000000000,          ENDING] PASSED.
        Child:  6.8  - F_TEST  [8000000000000000,               1] PASSED.
        Child:  6.9  - F_TEST  [8000000000000000,7fffffffffffffff] PASSED.
        Child:  6.10 - F_TEST  [8000000000000000,8000000000000000] PASSED.
        Parent: 6.11 - F_ULOCK [7fffffffffffffff,               1] PASSED.

Test #7 - Test parent/child mutual exclusion.
        Parent: 7.0  - F_TLOCK [             ffc,               9] PASSED.
        Parent: Wrote 'aaaa eh' to testfile [ 4092, 7 ].
        Parent: Now free child to run, should block on lock.
        Parent: Check data in file to insure child blocked.
        Parent: Read 'aaaa eh' from testfile [ 4092, 7 ].
        Parent: 7.1  - COMPARE [             ffc,               7] PASSED.
        Parent: Now unlock region so child will unblock.
        Parent: 7.2  - F_ULOCK [             ffc,               9] PASSED.
        Child:  7.3  - F_LOCK  [             ffc,               9] PASSED.
        Parent: Now try to regain lock, parent should block.
        Child:  Write child's version of the data and release lock.
        Child:  Wrote 'bebebebeb' to testfile [ 4092, 9 ].
        Child:  7.4  - F_ULOCK [             ffc,               9] PASSED.
        Parent: 7.5  - F_LOCK  [             ffc,               9] PASSED.
        Parent: Check data in file to insure child unblocked.
        Parent: Read 'bebebebeb' from testfile [ 4092, 9 ].
        Parent: 7.6  - COMPARE [             ffc,               9] PASSED.                                [75/1478]
        Parent: 7.7  - F_ULOCK [             ffc,               9] PASSED.

Test #8 - Rate test performing lock/unlock cycles.
        Parent: Performed 1000 lock/unlock cycles in 3520 msecs. [34090 lpm].

Test #10 - Make sure a locked region is split properly.
        Parent: 10.0  - F_TLOCK [               0,               3] PASSED.
        Parent: 10.1  - F_ULOCK [               1,               1] PASSED.
        Child:  10.2  - F_TEST  [               0,               1] PASSED.
        Child:  10.3  - F_TEST  [               2,               1] PASSED.
        Child:  10.4  - F_TEST  [               3,          ENDING] PASSED.
        Child:  10.5  - F_TEST  [               1,               1] PASSED.
        Parent: 10.6  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.7  - F_ULOCK [               2,               1] PASSED.
        Child:  10.8  - F_TEST  [               0,               3] PASSED.
        Parent: 10.9  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.10 - F_TLOCK [               1,               3] PASSED.
        Parent: 10.11 - F_ULOCK [               2,               1] PASSED.
        Child:  10.12 - F_TEST  [               1,               1] PASSED.
        Child:  10.13 - F_TEST  [               3,               1] PASSED.
        Child:  10.14 - F_TEST  [               4,          ENDING] PASSED.
        Child:  10.15 - F_TEST  [               2,               1] PASSED.
        Child:  10.16 - F_TEST  [               0,               1] PASSED.

Test #11 - Make sure close() releases the process's locks.                                                [50/1478]
        Parent: 11.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Child:  11.1  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: 11.3  - F_TLOCK [              1d,             5b7] PASSED.
        Parent: 11.4  - F_TLOCK [            2000,              57] PASSED.
        Parent: Closed testfile.
        Child:  11.5  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.6  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.7  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 13, 16 ].
        Parent: Closed testfile.
        Child:  11.8  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.9  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.10 - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Truncated testfile.
        Parent: Closed testfile.
        Child:  11.11 - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.12 - F_ULOCK [               0,          ENDING] PASSED.

Test #12 - Signalled process should release locks.
        Child:  12.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Killed child process.
        Parent: 12.1  - F_TLOCK [               0,          ENDING] PASSED.

Test #13 - Check locking and mmap semantics.                                                              [22/1478]
        Parent: 13.0  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: 13.1  - mmap [               0,            1000] WARNING!
        Parent: **** Expected EAGAIN, returned success...
        Parent: 13.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: unmap testfile.
        Parent: 13.3  - mmap [               0,            1000] PASSED.
        Parent: 13.4  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: unmap testfile.

Test #14 - Rate test performing I/O on unlocked and locked file.                                          [12/1478]
        Parent: File Unlocked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [455.92 +/- 1.73 KB/s].
        Parent: 14.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: File Locked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [442.91 +/- 4.10 KB/s].
        Parent: 14.1  - F_ULOCK [               0,          ENDING] PASSED.

Test #15 - Test 2nd open and I/O after lock and close.
        Parent: Second open succeeded.
        Parent: 15.0  - F_LOCK  [               0,          ENDING] PASSED.
        Parent: 15.1  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Parent: Wrote 'abcdefghij' to testfile [ 0, 11 ].
        Parent: Read 'abcdefghij' from testfile [ 0, 11 ].
        Parent: 15.2  - COMPARE [               0,               b] PASSED.

** PARENT pass 1 results: 49/49 pass, 1/1 warn, 0/0 fail (pass/total).

**  CHILD pass 1 results: 64/64 pass, 0/0 warn, 0/0 fail (pass/total).
Congratulations, you passed the locking tests!

All tests completed
```
  
</details>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [x] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _As mentioned in description existing and newly implemented UTs are passing_
- [x] **Documentation:** _This patch, merge request, Jira ticket [EOS-13989](https://jts.seagate.com/browse/EOS-13989) have up to date description_
- [x] **UT validation upon review completion** - Will do.