### PR TITLE
EOS-14672: Unit test is failing for XATTR

### DIFF
--- a/src/test/ut/cortxfs_xattr_ops.h
+++ b/src/test/ut/cortxfs_xattr_ops.h
@@ -20,6 +20,7 @@
 #include "ut_cortxfs_helper.h"
 #include <sys/xattr.h> /* XATTR_CREATE */
 
+#define XATTR_NAME_SIZE_MAX 255
 #define XATTR_VAL_SIZE_MAX 4096
 #define XATTR_ENV_FROM_STATE(__state) (*((struct ut_xattr_env **)__state))
 

--- a/src/test/ut/ut_cortxfs_xattr_ops.c
+++ b/src/test/ut/ut_cortxfs_xattr_ops.c
@@ -408,10 +408,15 @@ int listxattr_test_setup(void **state)
 	struct ut_xattr_env *ut_xattr_obj = XATTR_ENV_FROM_STATE(state);
 	struct ut_cfs_params *ut_cfs_obj = &ut_xattr_obj->ut_cfs_obj;
 
-	ut_xattr_obj->xattr[0] = file_name;
+
+	ut_xattr_obj->xattr = malloc(sizeof(char *) * (xattr_set_cnt+1));
+	ut_xattr_obj->xattr[0] = malloc(sizeof(char) * (strnlen(file_name, XATTR_NAME_SIZE_MAX)+1));
+	memcpy(ut_xattr_obj->xattr[0], file_name, (strnlen(file_name, XATTR_NAME_SIZE_MAX)+1));
 	for (i = 0; i<xattr_set_cnt; i++) {
-		ut_xattr_obj->xattr[i+1] = xattr_name[i];
+		ut_xattr_obj->xattr[i+1] = malloc(sizeof(char) * (strnlen(xattr_name[i], XATTR_NAME_SIZE_MAX)+1));
+		memcpy(ut_xattr_obj->xattr[i+1], xattr_name[i], (strnlen(xattr_name[i], XATTR_NAME_SIZE_MAX)+1));
 	}
+
 
 	rc = cfs_creat(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
 			&ut_cfs_obj->current_inode, file_name, 0755, &file_inode);
@@ -494,7 +499,7 @@ void listxattr_test(void **state)
  */
 int listxattr_test_teardown(void **state)
 {
-	int rc = 0;
+	int i, count, rc = 0;
 	struct ut_xattr_env *ut_xattr_obj = XATTR_ENV_FROM_STATE(state);
 	struct ut_cfs_params *ut_cfs_obj = &ut_xattr_obj->ut_cfs_obj;
 
@@ -502,6 +507,13 @@ int listxattr_test_teardown(void **state)
 		&ut_cfs_obj->current_inode, NULL, ut_xattr_obj->xattr[0]);
 
 	ut_assert_int_equal(rc, 0);
+
+	count = sizeof(ut_xattr_obj->xattr)/sizeof(ut_xattr_obj->xattr[0]);
+	for(i=0; i<count; i++)
+	{
+		free(ut_xattr_obj->xattr[i]);
+	}
+	free(ut_xattr_obj->xattr);
 
 	return rc;
 }


### PR DESCRIPTION
**Problem Description**
Unit test is failing for XATTR

**Solution Overview**
The issue was address of local variable was being referenced outside its host function.

**Unit Test Cases**
-bash-4.2$ sudo ./scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Note:
**Cthon test is not required for this changes as changes made only in UT file.**
