### PR TITLE
EOS-13996:ADDB:Profiling for all I/O operations (cortxfs repo)

### DIFF
--- a/src/tools/addb/scripts/addb2db_cortxfs.py
+++ b/src/tools/addb/scripts/addb2db_cortxfs.py
@@ -60,6 +60,7 @@ class entity_states(BaseModel):
     time        = IntegerField()
     tsdb_mod    = TextField()
     fn_tag      = TextField()
+    sm_tag      = TextField()
     entity_type = TextField()
     opid        = IntegerField()
     state_type  = TextField()
@@ -69,6 +70,7 @@ class entity_attributes(BaseModel):
     time        = IntegerField()
     tsdb_mod    = TextField()
     fn_tag      = TextField()
+    sm_tag      = TextField()
     entity_type = TextField()
     opid        = IntegerField()
     attr_name   = TextField()
@@ -79,6 +81,7 @@ class entity_maps(BaseModel):
     time        = IntegerField()
     tsdb_mod    = TextField()
     fn_tag      = TextField()
+    sm_tag      = TextField()
     entity_type = TextField()
     map_name    = IntegerField()
     src_opid    = IntegerField()
@@ -148,9 +151,10 @@ class ADDB2PPNFS:
         ret['time'] = ADDB2PPNFS.to_unix(row[1])
         ret['tsdb_mod'] = row[2]
         ret['fn_tag'] = row[3]
-        ret['entity_type'] = row[4]
-        ret['opid'] = int(row[5], 16)
-        ret['state_type'] = row[6]
+        ret['sm_tag'] = row[4]
+        ret['entity_type'] = row[5]
+        ret['opid'] = int(row[6], 16)
+        ret['state_type'] = row[7]
         return((table, ret))
 
     # [ '*',
@@ -168,11 +172,12 @@ class ADDB2PPNFS:
         ret['time'] = ADDB2PPNFS.to_unix(row[1])
         ret['tsdb_mod'] = row[2]
         ret['fn_tag'] = row[3]
-        ret['entity_type'] = row[4]
-        ret['opid'] = int(row[5], 16)
-        ret['attr_name'] = row[6]
+        ret['sm_tag'] = row[4]
+        ret['entity_type'] = row[5]
+        ret['opid'] = int(row[6], 16)
+        ret['attr_name'] = row[7]
         if ret['attr_name'].find("attr_time") == -1:
-            ret['attr_val'] = int(row[7], 16)
+            ret['attr_val'] = int(row[8], 16)
         else:
             ret['attr_val'] = "NA"
         return((table, ret))
@@ -192,11 +197,12 @@ class ADDB2PPNFS:
         ret['time'] = ADDB2PPNFS.to_unix(row[1])
         ret['tsdb_mod'] = row[2]
         ret['fn_tag'] = row[3]
-        ret['entity_type'] = row[4]
-        ret['map_name'] = int(row[5], 16)
-        ret['src_opid'] = int(row[6], 16)
-        ret['dst_opid'] = int(row[7], 16)
-        ret['clr_opid'] = int(row[8], 16)
+        ret['sm_tag'] = row[4]
+        ret['entity_type'] = row[5]
+        ret['map_name'] = int(row[6], 16)
+        ret['src_opid'] = int(row[7], 16)
+        ret['dst_opid'] = int(row[8], 16)
+        ret['clr_opid'] = int(row[9], 16)
         return((table, ret))
 
     def __init__(self):
@@ -219,7 +225,7 @@ class ADDB2PPNFS:
         row=  [s.strip('?') for s in row]
         if row== []:
             return
-        measurement_name = row[4]
+        measurement_name = row[5]
         labels=measurement_name
 
         for pname, (parser, table) in self.parsers.items():
@@ -295,16 +301,16 @@ def db_setup_loggers():
 
 def db_parse_args():
     parser = argparse.ArgumentParser(description="""
-addb2db_nfs.py: creates sql database containing performance samples from cortxfs
+addb2db_cortxfs.py: creates sql database containing performance samples from cortxfs
     """)
     parser.add_argument('--dumps', nargs='+', type=str, required=False,
                         default=["dump.txt", "dump_s.txt"],
                         help="""
 A bunch of addb2dump.txts can be passed here for processing:
-python3 addb2db_nfs.py --dumps dump1.txt dump2.txt ...
+python3 addb2db_cortxfs.py --dumps dump1.txt dump2.txt ...
 """)
     parser.add_argument('--db', type=str, required=False,
-                        default="nfscortxfs.db",
+                        default="cortxfs.db",
                         help="Output database file")
     parser.add_argument('--procs', type=int, required=False,
                         default=PROC_NR,

--- a/src/tools/addb/scripts/cortxfs_hist.py
+++ b/src/tools/addb/scripts/cortxfs_hist.py
@@ -21,12 +21,18 @@ import argparse
 import sys
 from peewee import SqliteDatabase
 from matplotlib import pyplot as plt
+import numpy as np
 
 DB      = SqliteDatabase(None)
 BLOCK   = 16<<10
 PROC_NR = 48
 DBBATCH = 95
 PID     = 0
+rec_limit = -1
+start_opid = 0
+timesort = "NA"
+sm_on = "NA"
+filter_op_id = -1
 
 def db_init(path):
     DB.init(path, pragmas={
@@ -44,14 +50,42 @@ def db_close():
 def gen_perfc_op_hist_graph(fn_tag: str="fsal_read", op_file: str="cortxfs_perfc_graph"):
     xvals_opids=[]
     yvals_time=[]
+    yvals_time_fsal=[]
+    yvals_time_kvs=[]
+    yvals_time_cfs=[]
+    yvals_time_dstore=[]
+    yvals_time_ds=[]
+    yvals_time_cortx_kvs=[]
+    yvals_time_m0=[]
+    yvals_time_init=[]
+    yvals_time_m0kvs=[]
+    yvals_time_m0_key_iter=[]
     xmax = 0
     ymax = 0
+    time_diff_fsal = 0
+    time_diff_kvs = 0
+    time_diff_cfs = 0
+    time_diff_dstore = 0
+    time_diff_ds = 0
+    time_diff_cortx_kvs = 0
+    time_diff_m0 = 0
+    time_diff_init = 0
+    time_diff_m0kvs = 0
+    time_diff_m0_key_iter = 0
+    processed_ops_clr = []
+    skip_it = 0
 
     with DB.atomic():
-        cursor = DB.execute_sql(f"SELECT DISTINCT opid from entity_states WHERE fn_tag LIKE \"{fn_tag}\" ORDER BY id ASC")
+        if filter_op_id != -1:
+            cursor = DB.execute_sql(f"SELECT DISTINCT opid from entity_states WHERE fn_tag LIKE \"{fn_tag}\" AND opid == {filter_op_id} ORDER BY id ASC")
+        elif rec_limit != -1:
+            cursor = DB.execute_sql(f"SELECT DISTINCT opid from entity_states WHERE fn_tag LIKE \"{fn_tag}\" AND opid >= {start_opid} ORDER BY id ASC LIMIT {rec_limit}")
+        else:
+            cursor = DB.execute_sql(f"SELECT DISTINCT opid from entity_states WHERE fn_tag LIKE \"{fn_tag}\" ORDER BY id ASC")
         field_opids = list(cursor.fetchall())
     label_opids = ("o");
     opids = [dict(zip(label_opids, f)) for f in field_opids]
+    # print (opids)
 
     if opids == []:
         print ("Could not find enough details in db for {0}", format(fn_tag))
@@ -61,8 +95,9 @@ def gen_perfc_op_hist_graph(fn_tag: str="fsal_read", op_file: str="cortxfs_perfc
         with DB.atomic():
             cursor = DB.execute_sql(f"SELECT * from entity_states WHERE opid = {opid['o']}")
             field_states = list(cursor.fetchall())
-        label_states = ("id", "pid", "time", "tsdb_mod", "fn_tag", "entity_type", "opid", "state_type");
+        label_states = ("id", "pid", "time", "tsdb_mod", "fn_tag", "sm_tag", "entity_type", "opid", "state_type");
         states = [dict(zip(label_states, f)) for f in field_states]
+        # print (states)
         t0 = -1
         t1 = -1
         for state in states:
@@ -74,25 +109,163 @@ def gen_perfc_op_hist_graph(fn_tag: str="fsal_read", op_file: str="cortxfs_perfc
             print (f"incomplete states, discarding this sample, {states}")
         else:
             time_diff = t1 - t0
-            # print (f"opid {opid['o']} took {time_diff} us to complete")
+            # print (f"opid {opid['o']} took {time_diff} ns to complete")
             xvals_opids.append(opid['o'])
             yvals_time.append(time_diff)
             if xmax < opid['o']:
                 xmax = opid['o']
             if ymax < time_diff:
                 ymax = time_diff
+            if sm_on not in "NA":
+                time_diff_fsal = 0
+                time_diff_kvs = 0
+                time_diff_cfs = 0
+                time_diff_dstore = 0
+                time_diff_ds = 0
+                time_diff_cortx_kvs = 0
+                time_diff_m0 = 0
+                time_diff_init = 0
+                time_diff_m0kvs = 0
+                time_diff_m0_key_iter = 0
+                with DB.atomic():
+                    cursor = DB.execute_sql(f"SELECT DISTINCT src_opid from entity_maps where dst_opid = {opid['o']}")
+                    field_sopids = list(cursor.fetchall())
+                label_sopids = ("s")
+                sopids = [dict(zip(label_sopids, f)) for f in field_sopids]
+                for sopid in sopids:
+                    with DB.atomic():
+                        cursor = DB.execute_sql(f"select time,opid,state_type,sm_tag from entity_states where opid = {sopid['s']}")
+                        field_sms = list(cursor.fetchall())
+
+                        cursor = DB.execute_sql(f"select * from entity_maps where src_opid = {sopid['s']}")
+                        field_sms_map = list(cursor.fetchall())
+
+                    label_sms = ("time", "opid", "state_type", "smtag")
+                    sms = [dict(zip(label_sms, f)) for f in field_sms]
+                    # print (sms)
+                    label_sms_map = ("id", "pid", "time", "tsdb_mod", "fn_tag", "sm_tag", "entity_type", "map_name", "src_opid", "dst_opid", "clr_opid")
+                    sms_map = [dict(zip(label_sms_map, f)) for f in field_sms_map]
+                    # print (sms_map[0])
+                    # print (sms_map[0]['clr_opid'])
+                    t0 = -1
+                    t1 = -1
+                    for sm in sms:
+                        if sm['state_type'] in "finish":
+                           t1 = sm['time']
+                        if sm['state_type'] in "init":
+                           t0 = sm['time']
+                    if t0 == -1 or t1 == -1:
+                        print (f"incomplete states, discarding this sample, {sms}")
+                    else:
+                        skip_it = 0
+                        for item in processed_ops_clr:
+                            if item['k'] == sm['smtag'] and item['v'] == sms_map[0]['clr_opid']:
+                                processed_ops_clr.append(dict({'k':sm['smtag'], 'v':sm['opid']}))
+                                skip_it = 1
+                                break
+                            if item['k'] == sm['smtag'] and item['v'] == sms_map[0]['dst_opid']:
+                                processed_ops_clr.append(dict({'k':sm['smtag'], 'v':sm['opid']}))
+                                skip_it = 1
+                                break
+                        if skip_it == 1:
+                            continue
+                        processed_ops_clr.append(dict({'k':sm['smtag'], 'v':sm['opid']}))
+                        time_diff = t1 - t0
+                        # print (f"{sm['smtag']} opid {sopid['s']} took {time_diff} ns to complete")
+                        if sm['smtag'] in "PST_FSAL":
+                            time_diff_fsal = time_diff_fsal + (t1 - t0)
+                        elif sm['smtag'] in "CFS":
+                            time_diff_kvs = time_diff_kvs + (t1 - t0)
+                        elif sm['smtag'] in "FSAL_CFS":
+                            time_diff_cfs = time_diff_cfs + (t1 - t0)
+                        elif sm['smtag'] in "DSAL":
+                            time_diff_dstore = time_diff_dstore + (t1 - t0)
+                        elif sm['smtag'] in "NSAL":
+                            time_diff_ds = time_diff_ds + (t1 - t0)
+                        elif sm['smtag'] in "UTILS":
+                            time_diff_cortx_kvs = time_diff_cortx_kvs + (t1 - t0)
+                        elif sm['smtag'] in "PST_M0":
+                            time_diff_m0 = time_diff_m0 + (t1 - t0)
+                        elif sm['smtag'] in "PST_INIT":
+                            time_diff_init = time_diff_init + (t1 - t0)
+                        elif sm['smtag'] in "PST_M0KVS":
+                            time_diff_m0kvs = time_diff_m0kvs + (t1 - t0)
+                        elif sm['smtag'] in "PST_M0_KEY_ITER":
+                            time_diff_m0_key_iter = time_diff_m0_key_iter + (t1 - t0)
+                yvals_time_fsal.append(time_diff_fsal)
+                yvals_time_kvs.append(time_diff_kvs)
+                yvals_time_cfs.append(time_diff_cfs)
+                yvals_time_dstore.append(time_diff_dstore)
+                yvals_time_ds.append(time_diff_ds)
+                yvals_time_cortx_kvs.append(time_diff_cortx_kvs)
+                yvals_time_m0.append(time_diff_m0)
+                yvals_time_init.append(time_diff_init)
+                yvals_time_m0kvs.append(time_diff_m0kvs)
+                yvals_time_m0_key_iter.append(time_diff_m0_key_iter)
+                # print ("total_sm_time: ")
+                # print (time_diff_fsal+time_diff_kvs+time_diff_cfs+time_diff_dstore+time_diff_ds+time_diff_cortx_kvs+time_diff_m0+time_diff_init+time_diff_m0kvs+time_diff_m0_key_iter)
+
+    if timesort not in "NA":
+        opid_time = dict(zip(xvals_opids, yvals_time))
+        if timesort in "INCR":
+            opid_time1 = dict(sorted(opid_time.items(), key=lambda x: x[1]))
+        else:
+            opid_time1 = dict(sorted(opid_time.items(), key=lambda x: x[1], reverse=True))
+        xvals_opids = list(opid_time1.keys())
+        yvals_time = list(opid_time1.values())
+
+    x = np.arange(len(xvals_opids))  # the label locations
+    width = 0.35  # the width of the bars
 
     fig, ax = plt.subplots()
-    ax.bar([idx for idx in range(len(xvals_opids))], yvals_time, align='edge', color='Red', width=0.3)
-    ax.set_xticks([idx for idx in range(len(xvals_opids))])
-    ax.set_xticklabels(xvals_opids, rotation=90, ha='center', size=3)
-    ax.set_yticklabels(yvals_time, rotation=90, ha='left', size=3)
-    fig.tight_layout()
-    fig.subplots_adjust(bottom=0.2)
+    rects1 = ax.bar(x + width/2, yvals_time, width, label='total')
+    if sm_on not in "NA":
+        if filter_op_id != -1:
+            rects3 = ax.bar(x + width/2 + 1, yvals_time_kvs, width, label='CFS')
+            rects4 = ax.bar(x + width/2 + 2, yvals_time_cfs, width, label='FSAL_CFS')
+            rects5 = ax.bar(x + width/2 + 3, yvals_time_dstore, width, label='DSAL')
+            rects6 = ax.bar(x + width/2 + 4, yvals_time_ds, width, label='NSAL')
+            rects7 = ax.bar(x + width/2 + 5, yvals_time_cortx_kvs, width, label='UTILS')
+        else:
+            rects3 = ax.bar(x, yvals_time_kvs, width, label='CFS')
+            rects4 = ax.bar(x, yvals_time_cfs, width, label='FSAL_CFS')
+            rects5 = ax.bar(x, yvals_time_dstore, width, label='DSAL')
+            rects6 = ax.bar(x, yvals_time_ds, width, label='NSAL')
+            rects7 = ax.bar(x, yvals_time_cortx_kvs, width, label='UTILS')
+
     plt.title(f"{fn_tag} \n time")
     plt.xlabel(f"{fn_tag} opid(s)")
-    plt.ylabel("time (us)")
-    plt.tight_layout()
+    plt.ylabel("time (ns)")
+    ax.set_xticks(x)
+    ax.set_xticklabels(xvals_opids, rotation=90, ha='center', size=3)
+    ax.set_yticklabels(yvals_time, rotation=90, ha='left', size=3)
+    ax.legend(loc='best', prop={'size': 6})
+    plt.legend(fontsize=4)
+
+    def autolabel(rects, yvals_time):
+        """Attach a text label above each bar in *rects*, displaying its height."""
+        idx = 0
+        for rect in rects:
+            height = rect.get_height()
+            text = ax.annotate(str(yvals_time[idx]).format(height),
+            xy=(rect.get_x() + rect.get_width() / 2, height),
+            xytext=(0, -3),  # 3 points vertical offset
+            textcoords="offset points",
+            ha='center', va='bottom')
+            idx=idx+1
+            text.set_rotation(90)
+            text.set_fontsize(3)
+
+    autolabel(rects1, yvals_time)
+    if sm_on not in "NA":
+        if filter_op_id != -1:
+            autolabel(rects3, yvals_time_kvs)
+            autolabel(rects4, yvals_time_cfs)
+            autolabel(rects5, yvals_time_dstore)
+            autolabel(rects6, yvals_time_ds)
+            autolabel(rects7, yvals_time_cortx_kvs)
+    fig.tight_layout()
+    fig.subplots_adjust(bottom=0.2)
     plt.savefig(fname=op_file, format="svg")
     print (f"Histogram graph render completed for operation {fn_tag}")
 
@@ -105,15 +278,57 @@ def parse_args():
     """)
     parser.add_argument("-d", "--db", type=str, default="cortxfs_perfc.db",
                         help="Performance database (cortxfs_perfc.db)")
-    parser.add_argument("fn_tag", type=str, help="A valid fn_tag from CORTXFS stack which is enabled for performance profiling")
-    parser.add_argument("-o", "--op_graph", type=str, default="cortxfs_hist_graph.png",
-                        help="CORTXFS fn_tag histogram graph output file (cortxfs_hist_graph.png)")
+    parser.add_argument("-ft", "--fn_tag", type=str,
+                        help="A valid fn_tag from CORTXFS stack which is "
+                        "enabled for performance profiling")
+    parser.add_argument("-rl", "--rec_limit", type=str, default="10",
+                        help="How many max opids to be shown in a single "
+                        "graph, use 'NA' to specify no limit. Default is 10")
+    parser.add_argument("-op", "--opid", type=str, default="NA",
+                        help="Get histogram of a specific opid")
+    parser.add_argument("-so", "--start_opid", type=str, default="0",
+                        help="Along with limit, from which opid the graph needs"
+                        "to be generated. Default is 0 to show from the start")
+    parser.add_argument("-st", "--sort_by_time", type=str, default="NA",
+                        help="Use this to time sort the returned results. "
+                        "Valid i/p are: INCR, DECR, NA. Default is NA. "
+                        " It can't be combined with --sub_mod_stats.")
+    parser.add_argument("-sm-stats", "--sub_mod_stats", type=str, default="NA",
+                        help=" 'YES' to see time stats for sub-modules."
+                        "Default set to 'NA'.")
+    parser.add_argument("-o", "--op_graph", type=str,
+                        default="cortxfs_hist_graph.svg",
+                        help="CORTXFS fn_tag histogram graph output file "
+                        " (cortxfs_hist_graph.svg)")
     return parser.parse_args()
 
 if __name__ == '__main__':
     args=parse_args()
+
+    start_opid = int(args.start_opid)
+
+    display_msg = f"Creating cortxfs histogram graph for fn_tag {args.fn_tag}, "
+
+    if args.opid not in "NA":
+        filter_op_id = int(args.opid)
+        display_msg = display_msg + f"for opid {filter_op_id}, "
+    else:
+        timesort = args.sort_by_time
+        display_msg = display_msg + f"timesort {timesort}, "
+        if args.rec_limit not in "NA":
+            rec_limit = int(args.rec_limit)
+            display_msg = display_msg + f"record max limit is {rec_limit}, "
+
+    if args.sub_mod_stats in "YES":
+        sm_on = "YES"
+        display_msg = display_msg + "sub module stats are enabled, "
+        if timesort not in "NA":
+            print ("Both --sub_mod_stats and --sort_by_time can not be used together")
+            exit (1)
+
+    print(f"{display_msg} from db file {args.db}, o/p file {args.op_graph}")
+
     db_init(args.db)
     db_connect()
-    print('Creating cortxfs histogram graph for fn_tag {0}, from db file {1}, o/p graph file {2}'. format(args.fn_tag, args.db, args.op_graph))
     gen_perfc_op_hist_graph(args.fn_tag, args.op_graph)
     db_close()

--- a/src/tools/addb/scripts/cortxfs_req.py
+++ b/src/tools/addb/scripts/cortxfs_req.py
@@ -58,9 +58,9 @@ def graph_node_add(g: Digraph, name: str, header: str, attrs: Dict):
 
 def gen_perfc_op_call_graph(fsal_op_id: int=None, op_file: str="cortxfs_perfc_graph"):
     ext_graph=None
-    label_maps = ("id", "pid", "time", "tsdb_mod", "fn_tag", "entity_type", "map_name", "src_opid", "dst_opid", "clr_opid");
-    label_attrs = ("id", "pid", "time", "tsdb_mod", "fn_tag", "entity_type", "opid", "attr_name", "attr_val");
-    label_states = ("id", "pid", "time", "tsdb_mod", "fn_tag", "entity_type", "opid", "state_type");
+    label_maps = ("id", "pid", "time", "tsdb_mod", "fn_tag", "sm_tag", "entity_type", "map_name", "src_opid", "dst_opid", "clr_opid");
+    label_attrs = ("id", "pid", "time", "tsdb_mod", "fn_tag", "sm_tag", "entity_type", "opid", "attr_name", "attr_val");
+    label_states = ("id", "pid", "time", "tsdb_mod", "fn_tag", "sm_tag", "entity_type", "opid", "state_type");
 
     with DB.atomic():
         cursor = DB.execute_sql(f"SELECT * from entity_states WHERE opid IN(SELECT ES.opid FROM entity_states ES JOIN entity_maps EM ON EM.src_opid = ES.opid AND EM.dst_opid = {fsal_op_id} OR ES.opid = {fsal_op_id} GROUP BY ES.opid) ORDER BY id ASC")


### PR DESCRIPTION
#  EOS-13996:ADDB:Profiling for all I/O operations (cortxfs repo)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## UT

[root@ssc-vm-c-0040 /]# ./cortx-posix/scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0


## Commit Message
commit 4d61e4eb5f9abbbaeca4cfdd6d2e408db05f6541
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Tue Oct 27 16:06:14 2020 -0600

            EOS-13996:ADDB:Profiling for all I/O operations (cortxfs repo)

            List of modified files:
                modified:   src/tools/addb/scripts/cortxfs_hist.py
                modified:   src/tools/addb/scripts/addb2db_cortxfs.py
                modified:   src/tools/addb/scripts/cortxfs_req.py
                Change description:
                        Add option to distinguish time taken by sub-modules
                    Add option to generate graph for a single opid
                Unit test:
                    histogram generation
            e.g. cortx-posix/cortxfs/src/tools/addb/scripts/cortxfs_hist.py [-h] [-d DB] [-ft FN_TAG] [-rl REC_LIMIT] [-op OPID] [-so START_OPID] [-st SORT_BY_TIME] [-sm-stats SUB_
                cortxfs_hist.py: Display histogram graph of a provided cortxfs function.
                optional arguments:
                  -h, --help            show this help message and exit
                  -d DB, --db DB        Performance database (cortxfs_perfc.db)
                  -ft FN_TAG, --fn_tag FN_TAG
                                        A valid fn_tag from CORTXFS stack which is enabled for
                                        performance profiling
                  -rl REC_LIMIT, --rec_limit REC_LIMIT
                                        How many max opids to be shown in a single graph, use
                                        'NA' to specify no limit. Default is 10
                  -op OPID, --opid OPID
                                        Get histogram of a specific opid
                  -so START_OPID, --start_opid START_OPID
                                        Along with limit, from which opid the graph needsto be
                                        generated. Default is 0 to show from the start
                  -st SORT_BY_TIME, --sort_by_time SORT_BY_TIME
                                        Use this to time sort the returned results. Valid i/p
                                        are: INCR, DECR, NA. Default is NA. It can't be
                                        combined with --sub_mod_stats.
                  -sm-stats SUB_MOD_STATS, --sub_mod_stats SUB_MOD_STATS
                                        'YES' to see time stats for sub-modules.Default set to
                                        'NA'.
                  -o OP_GRAPH, --op_graph OP_GRAPH
                                        CORTXFS fn_tag histogram graph output file
                                        (cortxfs_hist_graph.svg)

commit b99c6be4c05dab8aeaa92daede34dc7b95e9cb63
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Fri Oct 23 06:24:06 2020 -0600

        EOS-13996:ADDB:Profiling for all I/O operations (cortxfs repo)

        List of modified files:
        modified:   src/tools/addb/scripts/cortxfs_hist.py
            Change description:
                Add option to sort histogram charts based time (ascending order)
                Add option to get histogram charts of an opid range
            Unit test:
                histogram generation
            TODO: Add option to distinguish time taken by sub-modules (i.e. NSAL, DSAL etc)
        e.g.
                python3 cortx-posix/cortxfs/src/tools/addb/scripts/cortxfs_hist.py -d cortxfs_perfc_decoded.db -o read_hist.svg fsal_read -l 100 -sort-by-time YES
                python3 cortx-posix/cortxfs/src/tools/addb/scripts/cortxfs_hist.py
                usage: /home/751521/repos/github/repo1/cortx-posix/cortxfs/src/tools/addb/scripts/cortxfs_hist.py
                       [-h] [-d DB] [-l REC_LIMIT] [-so START_OPID]
                       [-sort-by-time SORT_OPTION] [-o OP_GRAPH]
                       fn_tag
                cortx-posix/cortxfs/src/tools/addb/scripts/cortxfs_hist.py: error: the following arguments are required: fn_tag
