### PR TITLE
EOS-14572: ADDB : Code refactor (cortxfs repo)

### DIFF
--- a/src/cortxfs/cortxfs_fh.c
+++ b/src/cortxfs/cortxfs_fh.c
@@ -30,6 +30,7 @@
 #include <common/log.h> /* log_err() */
 #include "kvtree.h" /* kvtree_lookup() */
 #include "operation.h" /* perf tracepoints */
+#include <cfs_perfc.h>
 
 /**
  * A unique key to be used in containers (maps, sets).

--- a/src/cortxfs/cortxfs_fops.c
+++ b/src/cortxfs/cortxfs_fops.c
@@ -29,6 +29,7 @@
 #include "kvtree.h"
 #include <errno.h>
 #include "operation.h"
+#include <cfs_perfc.h>
 
 int cfs_creat(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent_ino,
               char *name, mode_t mode, cfs_ino_t *newfile_ino)

--- a/src/cortxfs/cortxfs_ops.c
+++ b/src/cortxfs/cortxfs_ops.c
@@ -31,6 +31,7 @@
 #include <common.h> /* likely */
 #include "kvtree.h"
 #include "operation.h"
+#include <cfs_perfc.h>
 
 static int cfs_detach2(struct cfs_fh *parent_fh, struct cfs_fh *child_fh,
                        const cfs_cred_t *cred, const char *name);

--- a/src/include/cfs_perfc.h
+++ b/src/include/cfs_perfc.h
@@ -1,0 +1,67 @@
+/*
+ * Filename:	cfs_perfc.h
+ * Description:	This module defines performance counters and helpers.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
+#ifndef __CFS_PERF_COUNTERS_H_
+#define __CFS_PERF_COUNTERS_H_
+/******************************************************************************/
+#include "perf/tsdb.h" /* ACTION_ID_BASE */
+#include "operation.h"
+#include <pthread.h>
+#include <string.h>
+#include "debug.h"
+#include "perf/perf-counters.h"
+
+enum perfc_cfs_function_tags {
+	PFT_CFS_START = PFTR_RANGE_1_START,
+	PFT_CFS_READ,
+	PFT_CFS_WRITE,
+	PFT_CFS_GETATTR,
+	PFT_CFS_SETATTR,
+	PFT_CFS_ACCESS,
+	PFT_CFS_MKDIR,
+	PFT_CFS_RMDIR,
+	PFT_CFS_READDIR,
+	PFT_CFS_LOOKUP,
+	PFT_CFS_END = PFTR_RANGE_1_END
+};
+
+enum perfc_cfs_entity_attrs {
+	PEA_CFS_START = PEAR_RANGE_1_START,
+
+	PEA_R_C_COUNT,
+	PEA_R_C_OFFSET,
+	PEA_R_C_RES_RC,
+
+	PEA_GETATTR_RES_RC,
+
+	PEA_SETATTR_RES_RC,
+
+	PEA_ACCESS_FLAGS,
+	PEA_ACCESS_RES_RC,
+	PEA_CFS_END = PEAR_RANGE_1_END
+};
+
+enum perfc_cfs_entity_maps {
+	PEM_CFS_START = PEMR_RANGE_1_START,
+	PEM_CFS_TO_NFS,
+	PEM_CFS_END = PEMR_RANGE_1_END
+};
+
+/******************************************************************************/
+#endif /* __CFS_PERF_COUNTERS_H_ */


### PR DESCRIPTION
#  EOS-14572: ADDB : Code refactor (cortxfs repo)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## UT
[root@ssc-vm-c-0040 /]# ./cortx-posix/scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0


IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0


commit 97f8f620d921a6bc15a78049183ab35c5d788979
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Mon Nov 2 17:05:26 2020 -0700

                    EOS-14572: ADDB : Code refactor (cortxfs repo)
                    List of modified files:
                        modified:   src/cortxfs/cortxfs_fh.c
                        modified:   src/cortxfs/cortxfs_fops.c
                        modified:   src/cortxfs/cortxfs_ops.c
                        new file:   src/include/cfs_perfc.h
                    Change description:
                            Refactor function tags, maps and attribute enums and move out repo specific code. Introduce ranges. move out plugin.
                    Test:
                            On VM: UT, addb traces and graphs
