### PR TITLE
EOS-9006: Updated cfs_creat_ex cfs_readdir cfs_link and cfs_readlink …

### DIFF
--- a/src/cortxfs/cortxfs_fops.c
+++ b/src/cortxfs/cortxfs_fops.c
@@ -31,51 +31,46 @@
 #include "operation.h"
 #include <cfs_perfc.h>
 
-int cfs_creat(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent_ino,
-              char *name, mode_t mode, cfs_ino_t *newfile_ino)
+int cfs_creat(struct cfs_fh *parent_fh, cfs_cred_t *cred, char *name,
+              mode_t mode, cfs_ino_t *newfile_ino)
 {
 	int rc;
 	dstore_oid_t  oid;
-	struct cfs_fh *parent_fh = NULL;
+	cfs_ino_t child_ino = 0LL;
+	cfs_ino_t *parent_ino = NULL;
+	struct cfs_fs *cfs_fs = NULL;
 	struct stat *parent_stat = NULL;
 	struct dstore *dstore = dstore_get();
 
 	perfc_trace_inii(PFT_CFS_CREATE, PEM_CFS_TO_NFS);
-	dassert(dstore);
+	dassert(dstore && parent_fh && cred && name && newfile_ino);
 
-	/* TODO:Temp_FH_op - to be removed
-	 * Should get rid of creating and destroying FH operation in this
-	 * API when caller pass the valid FH instead of inode number
-	 */
-	RC_WRAP_LABEL(rc, out, cfs_fh_from_ino, cfs_fs, parent_ino, &parent_fh);
-
+	cfs_fs = cfs_fs_from_fh(parent_fh);
 	parent_stat = cfs_fh_stat(parent_fh);
+	parent_ino = cfs_fh_ino(parent_fh);
 
 	RC_WRAP_LABEL(rc, out, cfs_access_check, cred, parent_stat,
 		      CFS_ACCESS_WRITE);
 
 	/* Create tree entries, get new inode */
 	RC_WRAP_LABEL(rc, out, cfs_create_entry, parent_fh, cred, name, NULL,
-		      mode, newfile_ino, CFS_FT_FILE);
+		      mode, &child_ino, CFS_FT_FILE);
 
 	/* Get new unique extstore kfid */
 	RC_WRAP_LABEL(rc, out, dstore_get_new_objid, dstore, &oid);
 
 	/* Set the ino-kfid key-val in kvs */
-	RC_WRAP_LABEL(rc, out, cfs_set_ino_oid, cfs_fs, newfile_ino, &oid);
+	RC_WRAP_LABEL(rc, out, cfs_set_ino_oid, cfs_fs, &child_ino, &oid);
 
 	/* Create the backend object with passed kfid */
 	RC_WRAP_LABEL(rc, out, dstore_obj_create, dstore, cfs_fs, &oid);
+	*newfile_ino = child_ino;
 
 out:
-	if (parent_fh != NULL) {
-		cfs_fh_destroy_and_dump_stat(parent_fh);
-	}
-
-	log_trace("parent_ino=%llu name=%s newfile_ino=%llu rc=%d",
-		  *parent_ino, name, *newfile_ino, rc);
+	log_trace("parent_ino=%llu name=%s child_ino=%llu rc=%d",
+		  *parent_ino, name, child_ino, rc);
 	perfc_trace_attr(PEA_CFS_CREATE_PARENT_INODE, *parent_ino);
-	perfc_trace_attr(PEA_CFS_NEW_FILE_INODE, *newfile_ino);
+	perfc_trace_attr(PEA_CFS_NEW_FILE_INODE, child_ino);
 	perfc_trace_attr(PEA_CFS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return rc;
@@ -86,14 +81,22 @@ int cfs_creat_ex(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent,
 		 int stat_in_flags, cfs_ino_t *newfile,
 		 struct stat *stat_out)
 {
-	int rc;
+	int rc, rc2;
 	cfs_ino_t object = 0;
+	struct cfs_fh *parent_fh = NULL;
+	struct cfs_fh *child_fh = NULL;
 	struct kvstore *kvstor = kvstore_get();
 	struct kvs_idx index;
 
 	perfc_trace_inii(PFT_CFS_CREATE_EX, PEM_CFS_TO_NFS);
 	dassert(kvstor && cfs_fs && parent && name && stat_in && newfile &&
 		stat_out);
+
+	/* TODO:Temp_FH_op - to be removed
+	 * Should get rid of creating and destroying FH operation in this
+	 * API when caller pass the valid FH instead of inode number
+	 */
+	RC_WRAP_LABEL(rc, out, cfs_fh_from_ino, cfs_fs, parent, &parent_fh);
 
 	index = cfs_fs->kvtree->index;
 
@@ -103,27 +106,51 @@ int cfs_creat_ex(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent,
 
 	RC_WRAP(kvs_begin_transaction, kvstor, &index);
 
-	RC_WRAP_LABEL(rc, out, cfs_creat, cfs_fs, cred, parent, name,
-		      mode, &object);
-	RC_WRAP_LABEL(rc, out, cfs_setattr, cfs_fs, cred, &object, stat_in,
+	RC_WRAP_LABEL(rc, out, cfs_creat, parent_fh, cred, name, mode,
+		      &object);
+	RC_WRAP_LABEL(rc, cleanup, cfs_setattr, cfs_fs, cred, &object, stat_in,
 		      stat_in_flags);
-	RC_WRAP_LABEL(rc, out, cfs_getattr, cfs_fs, cred, &object, stat_out);
+	RC_WRAP_LABEL(rc, cleanup, cfs_getattr, cfs_fs, cred, &object,
+		      stat_out);
 
 	RC_WRAP(kvs_end_transaction, kvstor, &index);
 
 	*newfile = object;
 	object = 0;
 
-out:
+cleanup:
 	if (object != 0) {
+		rc2 = cfs_fh_from_ino(cfs_fs, &object, &child_fh);
+		/* Atleast we should be able to construct FH otherwise not
+		 * possible to operate further
+		 */
+		dassert(rc2 == 0);
+
 		/* We don't have transactions, so that let's just remove the
 		 * object.
 		 */
-		(void) cfs_unlink(cfs_fs, cred, parent, &object, name);
+		(void) cfs_unlink2(parent_fh, child_fh, cred, name);
 		(void) kvs_discard_transaction(kvstor, &index);
+
+		if (child_fh != NULL) {
+			cfs_fh_destroy(child_fh);
+		}
+
+		log_err("cfs_fs=%p parent_ino=%llu object=%llu name=%s rc=%d"
+			"rc2=%d", cfs_fs, *parent, object, name, rc, rc2);
 	}
+
+out:
+	if (parent_fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(parent_fh);
+	}
+
+	log_debug("cfs_fs=%p parent_ino=%llu new_ino=%llu name=%s rc=%d",
+		  cfs_fs, *parent, rc==0 ? *newfile : object, name, rc);
+
 	perfc_trace_attr(PEA_CFS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
 	return rc;
 }
 

--- a/src/include/cortxfs.h
+++ b/src/include/cortxfs.h
@@ -435,6 +435,22 @@ int cfs_rmdir(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent,
  * Destroys the link between 'dir' and 'fino' and removes
  * the 'fino' object from the namespace if it has no links.
  *
+ * @param[in] parent_fh - A parent file handle
+ * @param[in] child_fh - A child file handle of an object to be removed.
+ * @param[in] cred - User's credentials.
+ * @param[in] name - Name of the entry to be removed.
+ * @return 0 if successfull, otherwise -errno.
+ *
+ * @see ::cfs_destroy_orphaned_file and ::cfs_detach.
+ */
+int cfs_unlink2(struct cfs_fh *parent_fh, struct cfs_fh *child_fh,
+                cfs_cred_t *cred, char *name);
+
+/**
+ * Removes a file or a symbolic link.
+ * Destroys the link between 'dir' and 'fino' and removes
+ * the 'fino' object from the namespace if it has no links.
+ *
  * @param[in] fs_ctx - A context associated with the filesystem.
  * @param[in] cred - User's credentials.
  * @param[in] dir - Inode of the parent directory.
@@ -467,16 +483,16 @@ int cfs_readlink(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *link,
 /**
  * Creates a file.
  *
+ * @param parent_fh - A pointer to valid parent file handle
  * @param cred - pointer to user's credentials
- * @param parent - pointer to parent directory's inode.
  * @param name - name of the file to be created
  * @param mode - Unix mode for the new entry
  * @paran newino - [OUT] if successfuly, will point to newly created inode
  *
  * @return 0 if successful, a negative "-errno" value in case of failure
  */
-int cfs_creat(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent,
-	      char *name, mode_t mode, cfs_ino_t *newfile);
+int cfs_creat(struct cfs_fh *parent_fh, cfs_cred_t *cred, char *name,
+              mode_t mode, cfs_ino_t *newfile);
 
 /* Atomic file creation.
  * The functions create a new file, sets new attributes, gets them back

--- a/src/test/ut/ut_cortxfs_helper.c
+++ b/src/test/ut/ut_cortxfs_helper.c
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
  */
 
 #include "ut_cortxfs_helper.h"
@@ -102,14 +102,19 @@ int ut_file_create(void **state)
 {
 	int rc = 0;
 	struct ut_cfs_params *ut_cfs_obj = ENV_FROM_STATE(state);
+	cfs_ino_t *pinode = &ut_cfs_obj->parent_inode;
+	struct cfs_fh *parent_fh = NULL;
 
-	rc = cfs_creat(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-			&ut_cfs_obj->parent_inode, ut_cfs_obj->file_name, 0755,
-			&ut_cfs_obj->file_inode);
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs, pinode, &parent_fh);
+	ut_assert_int_equal(rc, 0);
+
+	rc = cfs_creat(parent_fh, &ut_cfs_obj->cred, ut_cfs_obj->file_name,
+		       0755, &ut_cfs_obj->file_inode);
 	if (rc) {
 		printf("Failed to create file %s\n", ut_cfs_obj->file_name);
 	}
 
+	cfs_fh_destroy_and_dump_stat(parent_fh);
 	return rc;
 }
 

--- a/src/test/ut/ut_cortxfs_helper.h
+++ b/src/test/ut/ut_cortxfs_helper.h
@@ -28,6 +28,7 @@
 #include "namespace.h"
 #include "ut.h"
 #include "cortxfs.h"
+#include "cortxfs_fh.h"
 
 #define DEFAULT_CONFIG "/etc/cortx/cortxfs.conf"
 #define CONF_FILE "/tmp/cortxfs/build-cortxfs/test/ut/ut_cortxfs.conf"

--- a/src/test/ut/ut_cortxfs_xattr_ops.c
+++ b/src/test/ut/ut_cortxfs_xattr_ops.c
@@ -407,7 +407,8 @@ int listxattr_test_setup(void **state)
 
 	struct ut_xattr_env *ut_xattr_obj = XATTR_ENV_FROM_STATE(state);
 	struct ut_cfs_params *ut_cfs_obj = &ut_xattr_obj->ut_cfs_obj;
-
+	struct cfs_fh *parent_fh = NULL;
+	cfs_ino_t *pinode = &ut_cfs_obj->current_inode;
 
 	ut_xattr_obj->xattr = malloc(sizeof(char *) * (xattr_set_cnt+1));
 	ut_xattr_obj->xattr[0] = malloc(sizeof(char) * (strnlen(file_name, XATTR_NAME_SIZE_MAX)+1));
@@ -418,8 +419,11 @@ int listxattr_test_setup(void **state)
 	}
 
 
-	rc = cfs_creat(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-			&ut_cfs_obj->current_inode, file_name, 0755, &file_inode);
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs, pinode, &parent_fh);
+	ut_assert_int_equal(rc, 0);
+
+	rc = cfs_creat(parent_fh, &ut_cfs_obj->cred, file_name, 0755,
+		       &file_inode);
 
 	ut_assert_int_equal(rc, 0);
 
@@ -433,6 +437,7 @@ int listxattr_test_setup(void **state)
 		ut_assert_int_equal(rc, 0);
 	}
 
+	cfs_fh_destroy_and_dump_stat(parent_fh);
 	return rc;
 }
 


### PR DESCRIPTION
# Cortx-fs Change Summary

## Problem Statement

_[EOS-9006](https://jts.seagate.com/browse/EOS-9006):_
_EOS-NFS: Update cfs_create_ex, cfs_link, cfs_readlink, cfs_readdir to use FH_

## Problem Description

_With recent changes in FH we decided to supply a valid FH to all of the API in cortxfs wherever it is required, so that task was divided in further small task and as a part of that we have to modify cfs_creat_ex cfs_link cfs_readlink and cfs_readdir API to use FH and optimize whatever was possible_

## Solution Overview

_Have modified cfs_creat_ex cfs_link cfs_readlink and cfs_readdir API to construct the FH based on given inode as input param and use it for further logic inside this API_

## Unit Test Cases

- _All UTs are passing - attached the log below in Testing section_
- _Cthon is passing  - attached the log below in Testing section_
- _Able to create FS, mount FS and do basic I/O on that_

## Note: 
_I have mounted /var/motr separately in order to avoid /var/motr is getting 100% full_

## Testing
<details>
  <summary>Click here to see the test execution output</summary>

```
After addressing review comments

# rtest
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests                                                                                         [49/119]
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

# sudo /opt/seagate/cortx/fs-ganesha/test/run_cthon.sh -m /mnt/dir1 -p fs1 -a                             [521/725]
sh ./runtests  -a -t /mnt/dir1/ssc-vm-0115.test

Starting BASIC tests: test directory /mnt/dir1/ssc-vm-0115.test (arg: -t)

./test1: File and directory creation test
        created 4 files 2 directories 2 levels deep in 0.37 seconds
        ./test1 ok.

./test2: File and directory removal test
        removed 4 files 2 directories 2 levels deep in 0.25 seconds
        ./test2 ok.

./test3: lookups across mount point
        500 getcwd and stat calls in 0.0  seconds
        ./test3 ok.

./test4: setattr, getattr, and lookup
        1000 chmods and stats on 10 files in 13.34 seconds
        ./test4 ok.
./test4a: getattr and lookup
        1000 stats on 10 files in 0.2  seconds
        ./test4a ok.

TESTARG=-t
./test6: readdir
        7500 entries read, 120 files in 50.86 seconds
        ./test6 ok.

./test7: link and rename
        200 renames and links on 10 files in 13.41 seconds
        ./test7 ok.

./test8: symlink and readlink                                                                             [488/725]
        400 symlinks and readlinks on 10 files in 12.52 seconds
        ./test8 ok.

./test9: statfs
        1500 statfs calls in 3.0  seconds
        ./test9 ok.

Congratulations, you passed the basic tests!

GENERAL TESTS: directory /mnt/dir1/ssc-vm-0115.test
if test ! -x runtests; then chmod a+x runtests; fi
cd /mnt/dir1/ssc-vm-0115.test; rm -f Makefile runtests runtests.wrk *.sh *.c mkdummy rmdummy nroff.in makefile.tst
cp Makefile runtests runtests.wrk *.sh *.c mkdummy rmdummy nroff.in makefile.tst /mnt/dir1/ssc-vm-0115.test

Small Compile
smcomp.time
        0.1 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Tbl
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Nroff
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Large Compile
        0.1 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Four simultaneous large compiles
        0.2 (0.0) real  0.1 (0.0) user  0.0 (0.0) sys

Makefile                                                                                                  [457/725]
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

General tests complete

SPECIAL TESTS: directory /mnt/dir1/ssc-vm-0115.test
cd /mnt/dir1/ssc-vm-0115.test; rm -f runtests runtests.wrk READWIN.txt Makefile op_unlk op_ren op_chmod dupreq excl
test negseek rename holey truncate nfsidem nstat stat stat2 touchn fstat rewind telldir bigfile bigfile2 freesp
cp runtests runtests.wrk READWIN.txt Makefile op_unlk op_ren op_chmod dupreq excltest negseek rename holey truncate
 nfsidem nstat stat stat2 touchn fstat rewind telldir bigfile bigfile2 freesp /mnt/dir1/ssc-vm-0115.test

check for proper open/unlink operation
nfsjunk files before unlink:
  -rw-rw-rw-. 1 root root 0 Nov  6 03:04 ./nfsuLbJ98
./nfsuLbJ98 open; unlink ret = 0
nfsjunk files after unlink:
  ls: cannot access ./nfsuLbJ98: No such file or directory
data compare ok
nfsjunk files after close:
  ls: cannot access ./nfsuLbJ98: No such file or directory
test completed successfully.

check for proper open/rename operation                                                                    [435/725]
nfsjunk files before rename:
  -rwxrwxrwx. 1 root root 0 Nov  6 03:04 ./nfsauWzpjn
  -rwxrwxrwx. 1 root root 0 Nov  6 03:04 ./nfsbCBEmca
./nfsbCBEmca open; rename ret = 0
nfsjunk files after rename:
  ls: cannot access ./nfsauWzpjn: No such file or directory
  -rwxrwxrwx. 1 root root 0 Nov  6 03:04 ./nfsbCBEmca
data compare ok
nfsjunk files after close:
  ls: cannot access ./nfsauWzpjn: No such file or directory
  ls: cannot access ./nfsbCBEmca: No such file or directory
test completed successfully.

check for proper open/chmod 0 operation
testfile before chmod:
  -rw-rw-rw-. 1 root root 0 Nov  6 03:04 ./nfszdy2qW
./nfszdy2qW open; chmod ret = 0
testfile after chmod:
  ----------. 1 root root 0 Nov  6 03:04 ./nfszdy2qW
data compare ok
testfile after write/read:
  ----------. 1 root root 100 Nov  6 03:04 ./nfszdy2qW
test completed successfully.

check for lost reply on non-idempotent requests
100 tries

test exclusive create.

test negative seek, you should get: read: Invalid argument                                                [405/725]
or lseek: Invalid argument
lseek: Invalid argument

test rename

test truncate
truncate succeeded

test holey file support
Holey file test ok

second check for lost reply on non-idempotent requests
testing 50 idempotencies in directory "testdir"

test rewind support

test telldir cookies

test freesp and file size
fcntl(...F_FREESP...) not available on this platform.

write/read 30 MB file

write/read at 2GB, 4GB edges

Special tests complete

Starting LOCKING tests: test directory /mnt/dir1/ssc-vm-0115.test (arg: -t)

Testing native post-LFS locking

Creating parent/child synchronization pipes.                                                              [373/725]

Test #1 - Test regions of an unlocked file.
        Parent: 1.1  - F_TEST  [               0,               1] PASSED.
        Parent: 1.2  - F_TEST  [               0,          ENDING] PASSED.
        Parent: 1.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Parent: 1.4  - F_TEST  [               1,               1] PASSED.
        Parent: 1.5  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 1.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Parent: 1.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Parent: 1.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Parent: 1.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.

Test #2 - Try to lock the whole file.
        Parent: 2.0  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  2.1  - F_TEST  [               0,               1] PASSED.
        Child:  2.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  2.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Child:  2.4  - F_TEST  [               1,               1] PASSED.
        Child:  2.5  - F_TEST  [               1,          ENDING] PASSED.
        Child:  2.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Child:  2.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  2.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  2.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.
        Parent: 2.10 - F_ULOCK [               0,          ENDING] PASSED.

Test #3 - Try to lock just the 1st byte.                                                                  [347/725]
        Parent: 3.0  - F_TLOCK [               0,               1] PASSED.
        Child:  3.1  - F_TEST  [               0,               1] PASSED.
        Child:  3.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  3.3  - F_TEST  [               1,               1] PASSED.
        Child:  3.4  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 3.5  - F_ULOCK [               0,               1] PASSED.

Test #4 - Try to lock the 2nd byte, test around it.
        Parent: 4.0  - F_TLOCK [               1,               1] PASSED.
        Child:  4.1  - F_TEST  [               0,               1] PASSED.
        Child:  4.2  - F_TEST  [               0,               2] PASSED.
        Child:  4.3  - F_TEST  [               0,          ENDING] PASSED.
        Child:  4.4  - F_TEST  [               1,               1] PASSED.
        Child:  4.5  - F_TEST  [               1,               2] PASSED.
        Child:  4.6  - F_TEST  [               1,          ENDING] PASSED.
        Child:  4.7  - F_TEST  [               2,               1] PASSED.
        Child:  4.8  - F_TEST  [               2,               2] PASSED.
        Child:  4.9  - F_TEST  [               2,          ENDING] PASSED.
        Parent: 4.10 - F_ULOCK [               1,               1] PASSED.

Test #5 - Try to lock 1st and 2nd bytes, test around them.                                                [326/725]
        Parent: 5.0  - F_TLOCK [               0,               1] PASSED.
        Parent: 5.1  - F_TLOCK [               2,               1] PASSED.
        Child:  5.2  - F_TEST  [               0,               1] PASSED.
        Child:  5.3  - F_TEST  [               0,               2] PASSED.
        Child:  5.4  - F_TEST  [               0,          ENDING] PASSED.
        Child:  5.5  - F_TEST  [               1,               1] PASSED.
        Child:  5.6  - F_TEST  [               1,               2] PASSED.
        Child:  5.7  - F_TEST  [               1,          ENDING] PASSED.
        Child:  5.8  - F_TEST  [               2,               1] PASSED.
        Child:  5.9  - F_TEST  [               2,               2] PASSED.
        Child:  5.10 - F_TEST  [               2,          ENDING] PASSED.
        Child:  5.11 - F_TEST  [               3,               1] PASSED.
        Child:  5.12 - F_TEST  [               3,               2] PASSED.
        Child:  5.13 - F_TEST  [               3,          ENDING] PASSED.
        Parent: 5.14 - F_ULOCK [               0,               1] PASSED.
        Parent: 5.15 - F_ULOCK [               2,               1] PASSED.

Test #6 - Try to lock the MAXEOF byte.
        Parent: 6.0  - F_TLOCK [7fffffffffffffff,               1] PASSED.
        Child:  6.1  - F_TEST  [7ffffffffffffffe,               1] PASSED.
        Child:  6.2  - F_TEST  [7ffffffffffffffe,               2] PASSED.
        Child:  6.3  - F_TEST  [7ffffffffffffffe,          ENDING] PASSED.
        Child:  6.4  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  6.5  - F_TEST  [7fffffffffffffff,               2] PASSED.
        Child:  6.6  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  6.7  - F_TEST  [8000000000000000,          ENDING] PASSED.
        Child:  6.8  - F_TEST  [8000000000000000,               1] PASSED.
        Child:  6.9  - F_TEST  [8000000000000000,7fffffffffffffff] PASSED.
        Child:  6.10 - F_TEST  [8000000000000000,8000000000000000] PASSED.
        Parent: 6.11 - F_ULOCK [7fffffffffffffff,               1] PASSED.

Test #7 - Test parent/child mutual exclusion.                                                             [294/725]
        Parent: 7.0  - F_TLOCK [             ffc,               9] PASSED.
        Parent: Wrote 'aaaa eh' to testfile [ 4092, 7 ].
        Parent: Now free child to run, should block on lock.
        Parent: Check data in file to insure child blocked.
        Parent: Read 'aaaa eh' from testfile [ 4092, 7 ].
        Parent: 7.1  - COMPARE [             ffc,               7] PASSED.
        Parent: Now unlock region so child will unblock.
        Parent: 7.2  - F_ULOCK [             ffc,               9] PASSED.
        Child:  7.3  - F_LOCK  [             ffc,               9] PASSED.
        Child:  Write child's version of the data and release lock.
        Parent: Now try to regain lock, parent should block.
        Child:  Wrote 'bebebebeb' to testfile [ 4092, 9 ].
        Child:  7.4  - F_ULOCK [             ffc,               9] PASSED.
        Parent: 7.5  - F_LOCK  [             ffc,               9] PASSED.
        Parent: Check data in file to insure child unblocked.
        Parent: Read 'bebebebeb' from testfile [ 4092, 9 ].
        Parent: 7.6  - COMPARE [             ffc,               9] PASSED.
        Parent: 7.7  - F_ULOCK [             ffc,               9] PASSED.

Test #8 - Rate test performing lock/unlock cycles.
        Parent: Performed 1000 lock/unlock cycles in 3430 msecs. [34985 lpm].

Test #10 - Make sure a locked region is split properly.                                                   [271/725]
        Parent: 10.0  - F_TLOCK [               0,               3] PASSED.
        Parent: 10.1  - F_ULOCK [               1,               1] PASSED.
        Child:  10.2  - F_TEST  [               0,               1] PASSED.
        Child:  10.3  - F_TEST  [               2,               1] PASSED.
        Child:  10.4  - F_TEST  [               3,          ENDING] PASSED.
        Child:  10.5  - F_TEST  [               1,               1] PASSED.
        Parent: 10.6  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.7  - F_ULOCK [               2,               1] PASSED.
        Child:  10.8  - F_TEST  [               0,               3] PASSED.
        Parent: 10.9  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.10 - F_TLOCK [               1,               3] PASSED.
        Parent: 10.11 - F_ULOCK [               2,               1] PASSED.
        Child:  10.12 - F_TEST  [               1,               1] PASSED.
        Child:  10.13 - F_TEST  [               3,               1] PASSED.
        Child:  10.14 - F_TEST  [               4,          ENDING] PASSED.
        Child:  10.15 - F_TEST  [               2,               1] PASSED.
        Child:  10.16 - F_TEST  [               0,               1] PASSED.

Test #11 - Make sure close() releases the process's locks.                                                [252/725]
        Parent: 11.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Child:  11.1  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: 11.3  - F_TLOCK [              1d,             5b7] PASSED.
        Parent: 11.4  - F_TLOCK [            2000,              57] PASSED.
        Parent: Closed testfile.
        Child:  11.5  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.6  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.7  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 13, 16 ].
        Parent: Closed testfile.
        Child:  11.8  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.9  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.10 - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Truncated testfile.
        Parent: Closed testfile.
        Child:  11.11 - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.12 - F_ULOCK [               0,          ENDING] PASSED.

Test #12 - Signalled process should release locks.
        Child:  12.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Killed child process.
        Parent: 12.1  - F_TLOCK [               0,          ENDING] PASSED.

Test #13 - Check locking and mmap semantics.                                                              [224/725]
        Parent: 13.0  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: 13.1  - mmap [               0,            1000] WARNING!
        Parent: **** Expected EAGAIN, returned success...
        Parent: 13.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: unmap testfile.
        Parent: 13.3  - mmap [               0,            1000] PASSED.
        Parent: 13.4  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: unmap testfile.

Test #14 - Rate test performing I/O on unlocked and locked file.
        Parent: File Unlocked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [465.03 +/- 1.61 KB/s].
        Parent: 14.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: File Locked                                                                               [200/725]
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [458.78 +/- 5.35 KB/s].
        Parent: 14.1  - F_ULOCK [               0,          ENDING] PASSED.

Test #15 - Test 2nd open and I/O after lock and close.
        Parent: Second open succeeded.
        Parent: 15.0  - F_LOCK  [               0,          ENDING] PASSED.
        Parent: 15.1  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Parent: Wrote 'abcdefghij' to testfile [ 0, 11 ].
        Parent: Read 'abcdefghij' from testfile [ 0, 11 ].
        Parent: 15.2  - COMPARE [               0,               b] PASSED.

** PARENT pass 1 results: 49/49 pass, 1/1 warn, 0/0 fail (pass/total).

**  CHILD pass 1 results: 64/64 pass, 0/0 warn, 0/0 fail (pass/total).

Testing non-native 64 bit LFS locking

Creating parent/child synchronization pipes.

Test #1 - Test regions of an unlocked file.                                                               [169/725]
        Parent: 1.1  - F_TEST  [               0,               1] PASSED.
        Parent: 1.2  - F_TEST  [               0,          ENDING] PASSED.
        Parent: 1.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Parent: 1.4  - F_TEST  [               1,               1] PASSED.
        Parent: 1.5  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 1.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Parent: 1.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Parent: 1.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Parent: 1.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.

Test #2 - Try to lock the whole file.
        Parent: 2.0  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  2.1  - F_TEST  [               0,               1] PASSED.
        Child:  2.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  2.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Child:  2.4  - F_TEST  [               1,               1] PASSED.
        Child:  2.5  - F_TEST  [               1,          ENDING] PASSED.
        Child:  2.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Child:  2.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  2.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  2.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.
        Parent: 2.10 - F_ULOCK [               0,          ENDING] PASSED.

Test #3 - Try to lock just the 1st byte.
        Parent: 3.0  - F_TLOCK [               0,               1] PASSED.
        Child:  3.1  - F_TEST  [               0,               1] PASSED.
        Child:  3.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  3.3  - F_TEST  [               1,               1] PASSED.
        Child:  3.4  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 3.5  - F_ULOCK [               0,               1] PASSED.

Test #4 - Try to lock the 2nd byte, test around it.                                                       [137/725]
        Parent: 4.0  - F_TLOCK [               1,               1] PASSED.
        Child:  4.1  - F_TEST  [               0,               1] PASSED.
        Child:  4.2  - F_TEST  [               0,               2] PASSED.
        Child:  4.3  - F_TEST  [               0,          ENDING] PASSED.
        Child:  4.4  - F_TEST  [               1,               1] PASSED.
        Child:  4.5  - F_TEST  [               1,               2] PASSED.
        Child:  4.6  - F_TEST  [               1,          ENDING] PASSED.
        Child:  4.7  - F_TEST  [               2,               1] PASSED.
        Child:  4.8  - F_TEST  [               2,               2] PASSED.
        Child:  4.9  - F_TEST  [               2,          ENDING] PASSED.
        Parent: 4.10 - F_ULOCK [               1,               1] PASSED.

Test #5 - Try to lock 1st and 2nd bytes, test around them.
        Parent: 5.0  - F_TLOCK [               0,               1] PASSED.
        Parent: 5.1  - F_TLOCK [               2,               1] PASSED.
        Child:  5.2  - F_TEST  [               0,               1] PASSED.
        Child:  5.3  - F_TEST  [               0,               2] PASSED.
        Child:  5.4  - F_TEST  [               0,          ENDING] PASSED.
        Child:  5.5  - F_TEST  [               1,               1] PASSED.
        Child:  5.6  - F_TEST  [               1,               2] PASSED.
        Child:  5.7  - F_TEST  [               1,          ENDING] PASSED.
        Child:  5.8  - F_TEST  [               2,               1] PASSED.
        Child:  5.9  - F_TEST  [               2,               2] PASSED.
        Child:  5.10 - F_TEST  [               2,          ENDING] PASSED.
        Child:  5.11 - F_TEST  [               3,               1] PASSED.
        Child:  5.12 - F_TEST  [               3,               2] PASSED.
        Child:  5.13 - F_TEST  [               3,          ENDING] PASSED.
        Parent: 5.14 - F_ULOCK [               0,               1] PASSED.
        Parent: 5.15 - F_ULOCK [               2,               1] PASSED.

Test #6 - Try to lock the MAXEOF byte.                                                                    [106/725]
        Parent: 6.0  - F_TLOCK [7fffffffffffffff,               1] PASSED.
        Child:  6.1  - F_TEST  [7ffffffffffffffe,               1] PASSED.
        Child:  6.2  - F_TEST  [7ffffffffffffffe,               2] PASSED.
        Child:  6.3  - F_TEST  [7ffffffffffffffe,          ENDING] PASSED.
        Child:  6.4  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  6.5  - F_TEST  [7fffffffffffffff,               2] PASSED.
        Child:  6.6  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  6.7  - F_TEST  [8000000000000000,          ENDING] PASSED.
        Child:  6.8  - F_TEST  [8000000000000000,               1] PASSED.
        Child:  6.9  - F_TEST  [8000000000000000,7fffffffffffffff] PASSED.
        Child:  6.10 - F_TEST  [8000000000000000,8000000000000000] PASSED.
        Parent: 6.11 - F_ULOCK [7fffffffffffffff,               1] PASSED.

Test #7 - Test parent/child mutual exclusion.                                                              [92/725]
        Parent: 7.0  - F_TLOCK [             ffc,               9] PASSED.
        Parent: Wrote 'aaaa eh' to testfile [ 4092, 7 ].
        Parent: Now free child to run, should block on lock.
        Parent: Check data in file to insure child blocked.
        Parent: Read 'aaaa eh' from testfile [ 4092, 7 ].
        Parent: 7.1  - COMPARE [             ffc,               7] PASSED.
        Parent: Now unlock region so child will unblock.
        Parent: 7.2  - F_ULOCK [             ffc,               9] PASSED.
        Child:  7.3  - F_LOCK  [             ffc,               9] PASSED.
        Child:  Write child's version of the data and release lock.
        Parent: Now try to regain lock, parent should block.
        Child:  Wrote 'bebebebeb' to testfile [ 4092, 9 ].
        Child:  7.4  - F_ULOCK [             ffc,               9] PASSED.
        Parent: 7.5  - F_LOCK  [             ffc,               9] PASSED.
        Parent: Check data in file to insure child unblocked.
        Parent: Read 'bebebebeb' from testfile [ 4092, 9 ].
        Parent: 7.6  - COMPARE [             ffc,               9] PASSED.
        Parent: 7.7  - F_ULOCK [             ffc,               9] PASSED.

Test #8 - Rate test performing lock/unlock cycles.
        Parent: Performed 1000 lock/unlock cycles in 3610 msecs. [33240 lpm].

Test #10 - Make sure a locked region is split properly.                                                    [69/725]
        Parent: 10.0  - F_TLOCK [               0,               3] PASSED.
        Parent: 10.1  - F_ULOCK [               1,               1] PASSED.
        Child:  10.2  - F_TEST  [               0,               1] PASSED.
        Child:  10.3  - F_TEST  [               2,               1] PASSED.
        Child:  10.4  - F_TEST  [               3,          ENDING] PASSED.
        Child:  10.5  - F_TEST  [               1,               1] PASSED.
        Parent: 10.6  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.7  - F_ULOCK [               2,               1] PASSED.
        Child:  10.8  - F_TEST  [               0,               3] PASSED.
        Parent: 10.9  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.10 - F_TLOCK [               1,               3] PASSED.
        Parent: 10.11 - F_ULOCK [               2,               1] PASSED.
        Child:  10.12 - F_TEST  [               1,               1] PASSED.
        Child:  10.13 - F_TEST  [               3,               1] PASSED.
        Child:  10.14 - F_TEST  [               4,          ENDING] PASSED.
        Child:  10.15 - F_TEST  [               2,               1] PASSED.
        Child:  10.16 - F_TEST  [               0,               1] PASSED.

Test #11 - Make sure close() releases the process's locks.                                                 [50/725]
        Parent: 11.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Child:  11.1  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: 11.3  - F_TLOCK [              1d,             5b7] PASSED.
        Parent: 11.4  - F_TLOCK [            2000,              57] PASSED.
        Parent: Closed testfile.
        Child:  11.5  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.6  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.7  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 13, 16 ].
        Parent: Closed testfile.
        Child:  11.8  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.9  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.10 - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Truncated testfile.
        Parent: Closed testfile.
        Child:  11.11 - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.12 - F_ULOCK [               0,          ENDING] PASSED.

Test #12 - Signalled process should release locks.
        Child:  12.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Killed child process.
        Parent: 12.1  - F_TLOCK [               0,          ENDING] PASSED.

Test #13 - Check locking and mmap semantics.                                                               [22/725]
        Parent: 13.0  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: 13.1  - mmap [               0,            1000] WARNING!
        Parent: **** Expected EAGAIN, returned success...
        Parent: 13.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: unmap testfile.
        Parent: 13.3  - mmap [               0,            1000] PASSED.
        Parent: 13.4  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: unmap testfile.

Test #14 - Rate test performing I/O on unlocked and locked file.
        Parent: File Unlocked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [438.73 +/- 1.50 KB/s].
        Parent: 14.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: File Locked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [403.79 +/- 3.20 KB/s].
        Parent: 14.1  - F_ULOCK [               0,          ENDING] PASSED.

Test #15 - Test 2nd open and I/O after lock and close.
        Parent: Second open succeeded.
        Parent: 15.0  - F_LOCK  [               0,          ENDING] PASSED.
        Parent: 15.1  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Parent: Wrote 'abcdefghij' to testfile [ 0, 11 ].
        Parent: Read 'abcdefghij' from testfile [ 0, 11 ].
        Parent: 15.2  - COMPARE [               0,               b] PASSED.

** PARENT pass 1 results: 49/49 pass, 1/1 warn, 0/0 fail (pass/total).

**  CHILD pass 1 results: 64/64 pass, 0/0 warn, 0/0 fail (pass/total).
Congratulations, you passed the locking tests!

All tests completed
```
  
</details>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [x] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _As mentioned in description existing and newly implemented UTs are passing_
- [x] **Documentation:** _This patch, merge request, Jira ticket [EOS-9006](https://jts.seagate.com/browse/EOS-9006) have up to date description_
- [x] **UT validation upon review completion** - Will do.