### PR TITLE
EOS-14772: Perfc APIs to detect uninitialized TLS (repo cortxfs)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,7 @@ set(DEFAULT_DSALINC "")
 set(DSALINC ${DEFAULT_DSALINC} CACHE PATH "Path to folder with dstore.h")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I\"${CMAKE_SOURCE_DIR}/include\"")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror -fPIC -g")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror -fPIC -g -lpthread")
 
 set(CORTXFS_BASE_VERSION ${BASE_VERSION})
 set(INSTALL_DIR_ROOT ${INSTALL_DIR_ROOT})

--- a/src/test/ut/ut_cortxfs_xattr_file_ops.c
+++ b/src/test/ut/ut_cortxfs_xattr_file_ops.c
@@ -18,6 +18,14 @@
  */
 
 #include "cortxfs_xattr_ops.h"
+#ifndef ENABLE_TSDB_ADDB
+#define ENABLE_TSDB_ADDB
+#endif
+#include <perf/perf-counters.h>
+#include <pthread.h>
+
+pthread_key_t perfc_tls_key;
+uint8_t perfc_tls_key_check = PERFC_INVALID_ID;
 
 /**
  * Setup for xattr test group.
@@ -77,6 +85,10 @@ int main(void)
 	int rc = 0;
 	char *test_log = "/var/log/cortx/test/ut/xattr_file_ops.log";
 
+	/*
+	 * uncomment below statement to enable addb traces in this UT
+	 * perfc_tsdb_setup();
+	 */
 	printf("Xattr file Tests\n");
 
 	rc = ut_init(test_log);


### PR DESCRIPTION
#  EOS-14772: Perfc APIs to detect uninitialized TLS (repo cortxfs)
## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## UT

[root@ssc-vm-c-0040 /]# ./cortx-posix/scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0


## Commit Message
commit c099a7741b333b9b4e8f451abc47b8c149cd2925
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Tue Nov 10 09:54:38 2020 -0700

                    EOS-14772: Perfc APIs to detect uninitialized TLS (repo cortxfs)
                    List of modified files:
                    modified:   src/CMakeLists.txt
                    modified:   src/test/ut/ut_cortxfs_xattr_file_ops.c
                    Change description:
                        Add a flag named perfc_tls_key_check to check if perfc_tls_key is not initialized.
                        If perfc_tls_key is found to be not initialized, then perfc APIs will be turned off
                        run time.
                        Add an API perfc_tsdb_setup() to init perfc_tls_key and perfc_tls_key_check. Caller
                        process should call this once before calling any perfc APIs to init the global tls
                        flag and variables.
                    For UT ut_cortxfs_xattr_file_op, the perfc traces are enabled as a demo to show how
                    cortxfs perfc can be enabled in external processess, such as UT.
                    Unit test:
                        Verified that with this change regular NFS IO is generating addb traces as expected.
                        UT runs are successful, for demo one of the UT ut_cortxfs_xattr_file_ops is using
                        perfc traces, it is generating traces. For rest of the UTs, perfc are not enabled
                        and the APIs are verified and found to be working as expected.

    Signed-off-by: pratyush-seagate <pratyush.k.khan@seagate.com>