### PR TITLE
EOS-15064: cortxfs perf: Expose bsize as a per file system configurable param and stop using m0store_get_bsize (repo cortxfs)

### DIFF
--- a/src/cortxfs/cortxfs_internal.c
+++ b/src/cortxfs/cortxfs_internal.c
@@ -630,6 +630,8 @@ int cfs_create_entry(struct cfs_fh *parent_fh, cfs_cred_t *cred, char *name,
 	bufstat.st_ctim.tv_sec = bufstat.st_atim.tv_sec;
 	bufstat.st_ctim.tv_nsec = bufstat.st_atim.tv_nsec;
 
+	bufstat.st_blksize = parent_stat->st_blksize;
+
 	switch (type) {
 	case CFS_FT_DIR:
 		bufstat.st_mode = S_IFDIR | mode;

--- a/src/cortxfscli/cortxfscli.py
+++ b/src/cortxfscli/cortxfscli.py
@@ -72,7 +72,8 @@ cortxfscli_default_validation_rules = """{
 			"Squash" : {"set" : "no_root_squash,root_squash"},
 			"access_type" : {"set" : "RW,R,W,None"},
 			"protocols" : {"set" : "3,4,4.1,3:4"},
-			"pnfs_enabled" : {"set" : "true,false"}
+			"pnfs_enabled" : {"set" : "true,false"},
+			"fs_bsize" : {"set": "4096,8192,16384,32768,65536,131072,262144,524288,1048576"}
 	},
 
 	"smb" : {
@@ -119,6 +120,15 @@ def validate_key_val(inp_key, inp_val, conf_vals):
 				int(conf_vals['limit']), inp_val) != True:
 					throw_exception_with_msg("Invalid:" + inp_key + "=" + \
 					inp_val + "must use regex:" +  conf_vals)
+		elif conf_key == 'integer':
+			if int(inp_val) > int(conf_vals['max']):
+				throw_exception_with_msg("Invalid:" + inp_key + "=" + inp_val\
+				+ ", value must be less than or equals to: " +\
+				conf_vals['max'])
+			if int(inp_val) < int(conf_vals['min']):
+				throw_exception_with_msg("Invalid:" + inp_key + "=" + inp_val\
+				+ ", value must be greater than or equals to: " +\
+				conf_vals['min'])
 
 def validate_inp_config_params(conf_data, inp_args):
 	inp_params = {}
@@ -167,13 +177,16 @@ class FsCommand(Command):
 		sbparser.add_argument('action', help='action', choices=['create', 'list', 'delete'])
 		sbparser.add_argument('args', nargs='*', default=[], help='fs command options')
 		sbparser.set_defaults(command=FsCommand)
+		sbparser.add_argument('-cv', '--config_validation',
+			help='Optional JSON config file for validation rules.',\
+			default=cortxfscli_validation_rule_dev)
 
 	def validate_args_payload(self, args):
 		if args.action.lower() == 'list' and len(args.args) != 0:
 			throw_exception_with_msg("Too many args for " + \
 			args.action.lower())
 
-		if args.action.lower() == 'create' or args.action.lower() == 'delete':
+		if args.action.lower() == 'delete':
 			if len(args.args) != 1:
 				throw_exception_with_msg("Too many or no args for " + \
 				args.action.lower())
@@ -183,6 +196,44 @@ class FsCommand(Command):
 				throw_exception_with_msg("Invalid FS param: " + fs +\
 				", allowed regex:" + fs_name_regex + ", allowed max len:"\
 				+ str(fs_name_max_len))
+			return
+
+		if args.action.lower() == 'create':
+			if len(args.args) != 2:
+				throw_exception_with_msg("Too many or no args for " + \
+				args.action.lower())
+			# arg[0] is FS name, check it
+			fs = args.args[0]
+			if regex_pattern_check(fs_name_regex, fs_name_max_len, fs) != True:
+				throw_exception_with_msg("Invalid FS param: " + fs +\
+				", allowed regex:" + fs_name_regex + ", allowed max len:"\
+				+ str(fs_name_max_len))
+			# args.args[1] is options for FS, must needed for create
+			# fs_bsize=<bsize> value is expected, check it
+			if len(args.args) != 2:
+				throw_exception_with_msg("Too many or no args for " + \
+				args.action.lower())
+			'''
+			Note:
+			Production build should not have any option to pass custom
+			validation rules to this tool. Disable them!
+			Must only use the embedded rules.
+			Priority:
+				1. If local dev version exists, i.e. cortxfscli_validation_rule_dev 
+				2. If user passed an existing file
+				3. Embedded
+			''' 
+			if os.path.isfile(cortxfscli_validation_rule_dev) == True:
+				print ("Using dev validation rules")
+				cortxfscli_config_rules = read_conf_file(cortxfscli_validation_rule_dev)
+			elif os.path.isfile(args.config_validation) == True:
+				print ("Using external validation rules")
+				cortxfscli_config_rules = read_conf_file(args.config_validation)
+			else:
+				print ("Using embedded validation rules")
+				cortxfscli_config_rules = json.loads(cortxfscli_default_validation_rules)
+
+			validate_inp_config_params(cortxfscli_config_rules, args.args[1])
 
 class EndpointCommand(Command):
 	"""

--- a/src/cortxfscli/cortxfscli_validation_rules.json
+++ b/src/cortxfscli/cortxfscli_validation_rules.json
@@ -6,11 +6,12 @@
             "Filesystem_id" : {"regex" : "[^^0-9+.0-9+$]", "limit" : "100"},
             "client" : {"max_count" : "10"},
             "clients" : {"regex" : "[^A-Za-z0-9.*/]", "limit" : "100"},
-            "disable_acl" : {"set" : "true,false"}
+            "disable_acl" : {"set" : "true,false"},
             "Squash" : {"set" : "no_root_squash,root_squash"},
             "access_type" : {"set" : "RW,R,W,None"},
             "protocols" : {"set" : "3,4,4.1,3:4"},
-            "pnfs_enabled" : {"set" : "true,false"}
+            "pnfs_enabled" : {"set" : "true,false"},
+            "fs_bsize" : {"set": "4096,8192,16384,32768,65536,131072,262144,524288,1048576"}
 	},
 
         "smb" : {

--- a/src/fs/fs.c
+++ b/src/fs/fs.c
@@ -341,7 +341,7 @@ out:
 	return rc;
 }
 
-int cfs_fs_create(const str256_t *fs_name)
+int cfs_fs_create(const str256_t *fs_name, const size_t *fsbsize)
 {
         int rc = 0;
 	struct namespace *ns;
@@ -379,6 +379,7 @@ int cfs_fs_create(const str256_t *fs_name)
 	bufstat.st_atim.tv_sec = 0;
 	bufstat.st_mtim.tv_sec = 0;
 	bufstat.st_ctim.tv_sec = 0;
+	bufstat.st_blksize = fsbsize != NULL ? *fsbsize : CFS_DEFAULT_BLOCKSIZE;
 
 	RC_WRAP_LABEL(rc, delete_ns, kvtree_create, ns, (void *)&bufstat,
 		      sizeof(struct stat), &kvtree);

--- a/src/include/cortxfs.h
+++ b/src/include/cortxfs.h
@@ -107,6 +107,12 @@ int cfs_endpoint_scan(int (*cfs_scan_cb)(const struct cfs_endpoint_info *info,
 #define CFS_DEFAULT_CONFIG "/etc/cortx/cortxfs.conf"
 
 #define CFS_ROOT_INODE 2LL
+/*
+ * We support block sizes from 2^12 (4K) t0 2^20 (1M).
+ */
+#define CFS_MIN_BLOCKSIZE 4096
+#define CFS_DEFAULT_BLOCKSIZE CFS_MIN_BLOCKSIZE
+#define CFS_MAX_BLOCKSIZE 1048576
 #define CFS_ROOT_UID 0
 
 typedef unsigned long long int cfs_ino_t;
@@ -189,6 +195,20 @@ typedef void *cfs_fs_ctx_t;
  * All below APIs need to be moved to internal headers
  * once all migration of cortxfs completes.
  */
+
+/*  cfs block size validator, returns 0 if valid */
+static inline int cfs_is_bsize_valid(size_t fs_bsize)
+{
+	int bsizes;
+	for (bsizes = CFS_MIN_BLOCKSIZE; bsizes <= CFS_MAX_BLOCKSIZE;
+	     bsizes <<= 1) {
+		if (bsizes == fs_bsize) {
+			return 0;
+		}
+	}
+	return -1;
+}
+
 /* Inode Attributes API */
 int cfs_amend_stat(struct stat *stat, int flags);
 

--- a/src/include/internal/fs.h
+++ b/src/include/internal/fs.h
@@ -54,9 +54,11 @@ int cfs_fs_fini(void);
  *
  * @fs_name - file system name structure.
  *
+ * @fs_bsize - optional fs blocksize
+ *
  * @return 0 if successful, a negative "-errno" value in case of failure
  */
-int cfs_fs_create(const str256_t *fs_name);
+int cfs_fs_create(const str256_t *fs_name, const size_t *fs_bsize);
 
 /**
  * Detele FileSystem..

--- a/src/test/ut/ut_cortxfs_endpoint_ops.c
+++ b/src/test/ut/ut_cortxfs_endpoint_ops.c
@@ -31,7 +31,7 @@ static void test_cfs_endpoint_create(void)
 	str256_t fs_name;
 	str256_from_cstr(fs_name, name, strlen(name));
 
-	rc = cfs_fs_create(&fs_name);
+	rc = cfs_fs_create(&fs_name, NULL);
 	ut_assert_int_equal(rc, 0);
 
 	const char *endpoint_options  = "{ \"proto\": \"nfs\", \"mode\": \"rw\", \"secType\": \"sys\", \"Filesystem_id\": \"192.168\", \"client\": \"1\", \"clients\": \"*\", \"Squash\": \"no_root_squash\", \"access_type\": \"RW\", \"protocols\": \"4\" }";

--- a/src/test/ut/ut_cortxfs_fs_ops.c
+++ b/src/test/ut/ut_cortxfs_fs_ops.c
@@ -28,7 +28,7 @@ static void test_cfs_fs_create(void)
 	char *name = "cortxfs";
 	str256_t fs_name;
 	str256_from_cstr(fs_name, name, strlen(name));
-	rc = cfs_fs_create(&fs_name);
+	rc = cfs_fs_create(&fs_name, NULL);
 
 	ut_assert_int_equal(rc, 0);
 }

--- a/src/test/ut/ut_cortxfs_helper.c
+++ b/src/test/ut/ut_cortxfs_helper.c
@@ -54,7 +54,7 @@ int ut_cfs_fs_setup(void **state)
 	str256_from_cstr(fs_name, ut_cfs_obj->fs_name,
 				strlen(ut_cfs_obj->fs_name));
 	rc = 0;
-	rc = cfs_fs_create(&fs_name);
+	rc = cfs_fs_create(&fs_name, NULL);
 
 	if (rc != 0) {
 		fprintf(stderr, "Failed to create FS %s, rc=%d\n",


### PR DESCRIPTION
#  EOS-15064: cortxfs perf: Expose bsize as a per file system configurable param and stop using m0store_get_bsize (repo cortxfs)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## UT

[root@ssc-vm-c-0040 /]# ./cortx-posix/scripts/test.sh

 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0


## Commit Message
commit 16ecdbf7535ee276b6182879c76b8a20778ef0e7
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Mon Nov 23 06:23:08 2020 +0000

        EOS-15064: cortxfs perf: Expose bsize as a per file system configurable param and stop using m0store_get_bsize (repo cortxfs)
        List of modified files:
                modified:   src/cortxfs/cortxfs_fops.c
                modified:   src/cortxfs/cortxfs_internal.c
                modified:   src/cortxfscli/cortxfscli.py
                modified:   src/cortxfscli/cortxfscli_validation_rules.json
                modified:   src/fs/fs.c
                modified:   src/include/cortxfs.h
                modified:   src/include/internal/fs.h
                modified:   src/management/fs.c
                modified:   src/test/ut/ut_cortxfs_endpoint_ops.c
                modified:   src/test/ut/ut_cortxfs_fs_ops.c
                modified:   src/test/ut/ut_cortxfs_helper.c
        Change description:
                Add a new optional blocksize parameter for file system create handler.
                Add the support for configurable block size in cortxfscli and nfs_setup.sh.
                Remove the usages of m0store_get_bsize and replace it with file system wide
                configured block size param. This parameter is stored in the stat attribue
                of the file system and its objects.
                Associated updates in ut to reflect API changes.
        Unit test:
                Using configured 4K block size:
                        Verified that with this change regular NFS IO (v4) is working.
                        UT runs are successful.
                        cthon run is successful.
                Note: While using less that 4K block size (e.g. 1K, 2K), ganesha is crashing, this needs to be
                debugged later.

    Signed-off-by: pratyush-seagate <pratyush.k.khan@seagate.com>
