### PR TITLE
EOS-13969: Implemented error handling for fs_delete REST API

### DIFF
--- a/src/include/internal/error_handler.h
+++ b/src/include/internal/error_handler.h
@@ -18,6 +18,16 @@
  */
 #ifndef ERROR_HANDLER_H_
 #define ERROR_HANDLER_H_
+
+/* User defined error codes set greater than unix error codes.*/
+enum error_code {
+	INVALID_ETAG = 133,		/* Invalid ETag */
+	BAD_DIGEST, 			/* Non-matching HASH */
+	MISSING_ETAG,			/* Object ETag is missing */
+	INVALID_PAYLOAD,		/* Payload data is invalid */
+	INVALID_PATH_PARAMS		/* Invalid REST API path parameters */
+};
+
 /**
  * ############ Error response mapping structure  #####################
  */
@@ -31,12 +41,30 @@ enum error_resp_id {
 	ERR_RES_INVALID_FSNAME = 1,
 	ERR_RES_FS_EXIST,
 
+	/* Response IDs for fs delete api */
+	ERR_RES_FS_NONEXIST,
+	ERR_RES_FS_EXPORT_EXIST,
+	ERR_RES_FS_NOT_EMPTY,
+
+	/* Generic IDs */
+	ERR_RES_INVALID_ETAG,
+	ERR_RES_BAD_DIGEST,
+	ERR_RES_MISSING_ETAG,
+	ERR_RES_INVALID_PAYLOAD,
+	ERR_RES_INVALID_PATH_PARAMS,
+
 	/* Default error response ID */
 	ERR_RES_DEFAULT,
 	ERR_RES_MAX
 };
 
-/* Returns an error response message based on the error code */
+/*
+ *	Mapping APIs corresponding to every REST API
+ *
+ *	Returns an error response message based on the error code
+ */
 const char* fs_create_errno_to_respmsg(int err_code);
+
+const char* fs_delete_errno_to_respmsg(int err_code);
 
 #endif /* ERROR_HANDLER_H_ */

--- a/src/management/error_handler.c
+++ b/src/management/error_handler.c
@@ -22,8 +22,24 @@
 
 const char *error_resp_messages[] = {
 	"Invalid error response ID",
+
+	/* fs create api error response */
 	"The filesystem name specified is not valid.",
 	"The filesystem name you tried to create already exists.",
+
+	/* fs delete api error response */
+	"The specified filesystem does not exist.",
+	"The filesystem you tried to delete is being exported.",
+	"The filesystem you tried to delete is not empty.",
+
+	/* Generic error responses */
+	"The ETag should not be passed for a resource which is not modifiable.",
+	"The HASH specified did not match what we received.",
+	"The Object ETag is not sent.",
+	"Invalid payload data passed.",
+	"Invalid parameters passed with the API path.",
+
+	/* Default error response */
 	"Generic error message. Check cortx logs for more information."
 };
 
@@ -38,6 +54,13 @@ const char* fs_create_errno_to_respmsg(int err_code)
 	case EEXIST:
 		resp_id = ERR_RES_FS_EXIST;
 		break;
+	/* Since filesystem name cannot be modified. */
+	case INVALID_ETAG:
+		resp_id = ERR_RES_INVALID_ETAG;
+		break;
+	case INVALID_PAYLOAD:
+		resp_id = ERR_RES_INVALID_PAYLOAD;
+		break;
 	default:
 		resp_id = ERR_RES_DEFAULT;
 	}
@@ -45,3 +68,35 @@ const char* fs_create_errno_to_respmsg(int err_code)
 	return error_resp_messages[resp_id];
 }
 
+const char* fs_delete_errno_to_respmsg(int err_code)
+{
+	enum error_resp_id resp_id;
+
+	switch (err_code) {
+	case ENOENT:
+		resp_id = ERR_RES_FS_NONEXIST;
+		break;
+	case EINVAL:
+		resp_id = ERR_RES_FS_EXPORT_EXIST;
+		break;
+	case ENOTEMPTY:
+		resp_id = ERR_RES_FS_NOT_EMPTY;
+		break;
+	case BAD_DIGEST:
+		resp_id = ERR_RES_BAD_DIGEST;
+		break;
+	case MISSING_ETAG:
+		resp_id = ERR_RES_MISSING_ETAG;
+		break;
+	case INVALID_PAYLOAD:
+		resp_id = ERR_RES_INVALID_PAYLOAD;
+		break;
+	case INVALID_PATH_PARAMS:
+		resp_id = ERR_RES_INVALID_PATH_PARAMS;
+		break;
+	default:
+		resp_id = ERR_RES_DEFAULT;
+	}
+
+	return error_resp_messages[resp_id];
+}


### PR DESCRIPTION
# CORTXFS Change Summary

## Problem Statement
_[EOS-13969](https://jts.seagate.com/browse/EOS-13969):_
_fs REST API error response changes for DELETE(DELETE http method) request_

## Problem Description
Integrated error response framework with fs delete API.
A mapping function was required to map the UNIX error code returned underlying infrastructure(cortxfs (CFS) layer) to appropriate error response ids.
These error response ids would in turn map with respective error messages.

Also handled the case for etags and mismatch of hashes.


## Solution Overview
 Implemented the mapping structure which maps the error code to respective error response messages.

## Unit Test Cases
Tested with curl command

```
1. trying to delete a filesystem when its is exported already
723986@ssc-vm-c-0219.colo.seagate.com:/home/723986/rpmbuild/RPMS/x86_64
$ curl -v -X DELETE "http://localhost:8081/fs/fs7" -H  "accept: */*" -H "If-Match: 3f0616345735503a36ce42e6af6166e7"

{ "error_code": 22, "message": "The filesystem you tried to delete is being exported." }

2. deleting a non-existing filesystem
723986@ssc-vm-c-0219.colo.seagate.com:/home/723986/rpmbuild/RPMS/x86_64
$ curl -v -X DELETE "http://localhost:8081/fs/fs7" -H  "accept: */*" -H "If-Match: 3f0616345735503a36ce42e6af6166e7"

{ "error_code": 2, "message": "The specified filesystem does not exist." }

3. deleting a filesystem that is not exported without etag sent.
723986@ssc-vm-c-0219.colo.seagate.com:/home/723986/rpmbuild/RPMS/x86_64
$ curl -v -X DELETE "http://localhost:8081/fs/testFS" -H  "accept: */*"

{ "error_code": 135, "message": "The Object ETag is not sent." }

4. deleting filesystem with the wrong etag being passed 
$ curl -v -X DELETE "http://localhost:8081/fs/testFS" -H  "accept: */*" -H "If-Match: 3f0616345735503a36ce42e6af61"

{ "error_code": 134, "message": "The HASH specified did not match what we received." }

5. deleting filesystem with correct etag being passed
$ curl -v -X DELETE "http://localhost:8081/fs/testFS" -H  "accept: */*" -H "If-Match: 3f0616345735503a36ce42e6af6166e"

* About to connect() to localhost port 8081 (#0)
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8081 (#0)
> DELETE /fs/testFS HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:8081
> accept: */*
> If-Match: 3f0616345735503a36ce42e6af6166e7
>
< HTTP/1.1 200 OK
< Content-Length:
< Content-Length: 0
< Content-Type: text/plain
<
* Connection #0 to host localhost left intact

6. deleting filesystem but passing payload data which is not allowed
$ curl -v -X DELETE "http://localhost:8081/fs/fs7" -H  "accept: */*" -H "If-Match: 6f0616345735503a36ce42e6af6166e7" -d "kl"

{ "error_code": 136, "message": "Invalid payload data passed." }

7. deleting filesystem with invalid path params
$ curl -v -X DELETE http://localhost:8081/fs/ -H 'accept: */*' -H 'If-Match: 3f0616345735503a36ce42e6af6166e7'

{ "error_code": 137, "message": "Invalid parameters passed with the API path." }

8. passing etag to create filesystem API which is not allowed.
$ curl -v -X PUT "http://localhost:8081/fs" -H "accept: */*" -H "Content-Type: application/json" -H "If-Match: cc89022a51522f705c44fcfced188cc8" -d "{\"name\":\"testFS\"}"
* Connection #0 to host localhost left intact
{ "error_code": 133, "message": "The ETag should not be passed for a resource which is not modifiable." }

```
## Testing
<details>
  <summary>Click here to see the test execution output</summary>

```
723986@ssc-vm-c-0219.colo.seagate.com:/home/723986/ztest/cortx-posix5 (main)
$ sudo ./scripts/test.sh
[sudo] password for 723986:
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0


```

</details>

<details>
<summary> cthon test output </summary>


```

723986@ssc-vm-c-0219.colo.seagate.com:/home/723986
$ sudo /opt/seagate/cortx/fs-ganesha/test/run_cthon.sh -f -p fs7 -m /tmp/
sh ./runtests  -a -f /tmp//ssc-vm-c-0219.test

Starting BASIC tests: test directory /tmp//ssc-vm-c-0219.test (arg: -f)

./test1: File and directory creation test
        created 6 files 6 directories 2 levels deep
        ./test1 ok.

./test2: File and directory removal test
        removed 6 files 6 directories 2 levels deep
        ./test2 ok.

./test3: lookups across mount point
        2 getcwd and stat calls
        ./test3 ok.

./test4: setattr, getattr, and lookup
        20 chmods and stats on 10 files
        ./test4 ok.
./test4a: getattr and lookup
        20 stats on 10 files
        ./test4a ok.

TESTARG=-f
./test6: readdir
        122 entries read, 120 files
        ./test6 ok.

./test7: link and rename
        20 renames and links on 10 files
        ./test7 ok.

./test8: symlink and readlink
        20 symlinks and readlinks on 10 files
        ./test8 ok.

./test9: statfs
        1 statfs calls
        ./test9 ok.

Congratulations, you passed the basic tests!

GENERAL TESTS: directory /tmp//ssc-vm-c-0219.test
if test ! -x runtests; then chmod a+x runtests; fi
cd /tmp//ssc-vm-c-0219.test; rm -f Makefile runtests runtests.wrk *.sh *.c mkdummy rmdummy nroff.in makefile.tst
cp Makefile runtests runtests.wrk *.sh *.c mkdummy rmdummy nroff.in makefile.tst /tmp//ssc-vm-c-0219.test

Small Compile
smcomp.time
        0.1 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Tbl
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Nroff
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Large Compile
        0.1 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Four simultaneous large compiles
        0.2 (0.0) real  0.1 (0.0) user  0.0 (0.0) sys

Makefile
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

General tests complete

SPECIAL TESTS: directory /tmp//ssc-vm-c-0219.test
cd /tmp//ssc-vm-c-0219.test; rm -f runtests runtests.wrk READWIN.txt Makefile op_unlk op_ren op_chmod dupreq excltest negseek rename holey truncate nfsidem nstat stat stat2 touchn fstat rewind telldir bigfile bigfile2 freesp
cp runtests runtests.wrk READWIN.txt Makefile op_unlk op_ren op_chmod dupreq excltest negseek rename holey truncate nfsidem nstat stat stat2 touchn fstat rewind telldir bigfile bigfile2 freesp /tmp//ssc-vm-c-0219.test

check for proper open/unlink operation
nfsjunk files before unlink:
  -rw-rw-rw- 1 root root 0 Nov 24 22:09 ./nfsoG9t6i
./nfsoG9t6i open; unlink ret = 0
nfsjunk files after unlink:
  ls: cannot access ./nfsoG9t6i: No such file or directory
data compare ok
nfsjunk files after close:
  ls: cannot access ./nfsoG9t6i: No such file or directory
test completed successfully.

check for proper open/rename operation
nfsjunk files before rename:
  -rwxrwxrwx 1 root root 0 Nov 24 22:09 ./nfsauJ9Tjv
  -rwxrwxrwx 1 root root 0 Nov 24 22:09 ./nfsb8mgkhq
./nfsb8mgkhq open; rename ret = 0
nfsjunk files after rename:
  ls: cannot access ./nfsauJ9Tjv: No such file or directory
  -rwxrwxrwx 1 root root 0 Nov 24 22:09 ./nfsb8mgkhq
data compare ok
nfsjunk files after close:
  ls: cannot access ./nfsauJ9Tjv: No such file or directory
  ls: cannot access ./nfsb8mgkhq: No such file or directory
test completed successfully.

check for proper open/chmod 0 operation
testfile before chmod:
  -rw-rw-rw- 1 root root 0 Nov 24 22:09 ./nfsbUWWl9
./nfsbUWWl9 open; chmod ret = 0
testfile after chmod:
  ---------- 1 root root 0 Nov 24 22:09 ./nfsbUWWl9
data compare ok
testfile after write/read:
  ---------- 1 root root 100 Nov 24 22:09 ./nfsbUWWl9
test completed successfully.

check for lost reply on non-idempotent requests
100 tries

test exclusive create.

test negative seek, you should get: read: Invalid argument
or lseek: Invalid argument
lseek: Invalid argument

test rename

test truncate
truncate succeeded

test holey file support
Holey file test ok

second check for lost reply on non-idempotent requests
testing 50 idempotencies in directory "testdir"

test rewind support

test telldir cookies

test freesp and file size
fcntl(...F_FREESP...) not available on this platform.

write/read 30 MB file

write/read at 2GB, 4GB edges

Special tests complete

Starting LOCKING tests: test directory /tmp//ssc-vm-c-0219.test (arg: -f)

Testing native post-LFS locking

Creating parent/child synchronization pipes.

Test #1 - Test regions of an unlocked file.
        Parent: 1.1  - F_TEST  [               0,               1] PASSED.
        Parent: 1.2  - F_TEST  [               0,          ENDING] PASSED.
        Parent: 1.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Parent: 1.4  - F_TEST  [               1,               1] PASSED.
        Parent: 1.5  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 1.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Parent: 1.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Parent: 1.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Parent: 1.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.

Test #2 - Try to lock the whole file.
        Parent: 2.0  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  2.1  - F_TEST  [               0,               1] PASSED.
        Child:  2.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  2.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Child:  2.4  - F_TEST  [               1,               1] PASSED.
        Child:  2.5  - F_TEST  [               1,          ENDING] PASSED.
        Child:  2.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Child:  2.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  2.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  2.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.
        Parent: 2.10 - F_ULOCK [               0,          ENDING] PASSED.

Test #3 - Try to lock just the 1st byte.
        Parent: 3.0  - F_TLOCK [               0,               1] PASSED.
        Child:  3.1  - F_TEST  [               0,               1] PASSED.
        Child:  3.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  3.3  - F_TEST  [               1,               1] PASSED.
        Child:  3.4  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 3.5  - F_ULOCK [               0,               1] PASSED.

Test #4 - Try to lock the 2nd byte, test around it.
        Parent: 4.0  - F_TLOCK [               1,               1] PASSED.
        Child:  4.1  - F_TEST  [               0,               1] PASSED.
        Child:  4.2  - F_TEST  [               0,               2] PASSED.
        Child:  4.3  - F_TEST  [               0,          ENDING] PASSED.
        Child:  4.4  - F_TEST  [               1,               1] PASSED.
        Child:  4.5  - F_TEST  [               1,               2] PASSED.
        Child:  4.6  - F_TEST  [               1,          ENDING] PASSED.
        Child:  4.7  - F_TEST  [               2,               1] PASSED.
        Child:  4.8  - F_TEST  [               2,               2] PASSED.
        Child:  4.9  - F_TEST  [               2,          ENDING] PASSED.
        Parent: 4.10 - F_ULOCK [               1,               1] PASSED.

Test #5 - Try to lock 1st and 2nd bytes, test around them.
        Parent: 5.0  - F_TLOCK [               0,               1] PASSED.
        Parent: 5.1  - F_TLOCK [               2,               1] PASSED.
        Child:  5.2  - F_TEST  [               0,               1] PASSED.
        Child:  5.3  - F_TEST  [               0,               2] PASSED.
        Child:  5.4  - F_TEST  [               0,          ENDING] PASSED.
        Child:  5.5  - F_TEST  [               1,               1] PASSED.
        Child:  5.6  - F_TEST  [               1,               2] PASSED.
        Child:  5.7  - F_TEST  [               1,          ENDING] PASSED.
        Child:  5.8  - F_TEST  [               2,               1] PASSED.
        Child:  5.9  - F_TEST  [               2,               2] PASSED.
        Child:  5.10 - F_TEST  [               2,          ENDING] PASSED.
        Child:  5.11 - F_TEST  [               3,               1] PASSED.
        Child:  5.12 - F_TEST  [               3,               2] PASSED.
        Child:  5.13 - F_TEST  [               3,          ENDING] PASSED.
        Parent: 5.14 - F_ULOCK [               0,               1] PASSED.
        Parent: 5.15 - F_ULOCK [               2,               1] PASSED.

Test #6 - Try to lock the MAXEOF byte.
        Parent: 6.0  - F_TLOCK [7fffffffffffffff,               1] PASSED.
        Child:  6.1  - F_TEST  [7ffffffffffffffe,               1] PASSED.
        Child:  6.2  - F_TEST  [7ffffffffffffffe,               2] PASSED.
        Child:  6.3  - F_TEST  [7ffffffffffffffe,          ENDING] PASSED.
        Child:  6.4  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  6.5  - F_TEST  [7fffffffffffffff,               2] PASSED.
        Child:  6.6  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  6.7  - F_TEST  [8000000000000000,          ENDING] PASSED.
        Child:  6.8  - F_TEST  [8000000000000000,               1] PASSED.
        Child:  6.9  - F_TEST  [8000000000000000,7fffffffffffffff] PASSED.
        Child:  6.10 - F_TEST  [8000000000000000,8000000000000000] PASSED.
        Parent: 6.11 - F_ULOCK [7fffffffffffffff,               1] PASSED.

Test #7 - Test parent/child mutual exclusion.
        Parent: 7.0  - F_TLOCK [             ffc,               9] PASSED.
        Parent: Wrote 'aaaa eh' to testfile [ 4092, 7 ].
        Parent: Now free child to run, should block on lock.
        Parent: Check data in file to insure child blocked.
        Parent: Read 'aaaa eh' from testfile [ 4092, 7 ].
        Parent: 7.1  - COMPARE [             ffc,               7] PASSED.
        Parent: Now unlock region so child will unblock.
        Parent: 7.2  - F_ULOCK [             ffc,               9] PASSED.
        Child:  7.3  - F_LOCK  [             ffc,               9] PASSED.
        Child:  Write child's version of the data and release lock.
        Parent: Now try to regain lock, parent should block.
        Child:  Wrote 'bebebebeb' to testfile [ 4092, 9 ].
        Child:  7.4  - F_ULOCK [             ffc,               9] PASSED.
        Parent: 7.5  - F_LOCK  [             ffc,               9] PASSED.
        Parent: Check data in file to insure child unblocked.
        Parent: Read 'bebebebeb' from testfile [ 4092, 9 ].
        Parent: 7.6  - COMPARE [             ffc,               9] PASSED.
        Parent: 7.7  - F_ULOCK [             ffc,               9] PASSED.

Test #10 - Make sure a locked region is split properly.
        Parent: 10.0  - F_TLOCK [               0,               3] PASSED.
        Parent: 10.1  - F_ULOCK [               1,               1] PASSED.
        Child:  10.2  - F_TEST  [               0,               1] PASSED.
        Child:  10.3  - F_TEST  [               2,               1] PASSED.
        Child:  10.4  - F_TEST  [               3,          ENDING] PASSED.
        Child:  10.5  - F_TEST  [               1,               1] PASSED.
        Parent: 10.6  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.7  - F_ULOCK [               2,               1] PASSED.
        Child:  10.8  - F_TEST  [               0,               3] PASSED.
        Parent: 10.9  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.10 - F_TLOCK [               1,               3] PASSED.
        Parent: 10.11 - F_ULOCK [               2,               1] PASSED.
        Child:  10.12 - F_TEST  [               1,               1] PASSED.
        Child:  10.13 - F_TEST  [               3,               1] PASSED.
        Child:  10.14 - F_TEST  [               4,          ENDING] PASSED.
        Child:  10.15 - F_TEST  [               2,               1] PASSED.
        Child:  10.16 - F_TEST  [               0,               1] PASSED.

Test #11 - Make sure close() releases the process's locks.
        Parent: 11.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Child:  11.1  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: 11.3  - F_TLOCK [              1d,             5b7] PASSED.
        Parent: 11.4  - F_TLOCK [            2000,              57] PASSED.
        Parent: Closed testfile.
        Child:  11.5  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.6  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.7  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 13, 16 ].
        Parent: Closed testfile.
        Child:  11.8  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.9  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.10 - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Truncated testfile.
        Parent: Closed testfile.
        Child:  11.11 - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.12 - F_ULOCK [               0,          ENDING] PASSED.

Test #12 - Signalled process should release locks.
        Child:  12.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Killed child process.
        Parent: 12.1  - F_TLOCK [               0,          ENDING] PASSED.

Test #13 - Check locking and mmap semantics.
        Parent: 13.0  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: 13.1  - mmap [               0,            1000] WARNING!
        Parent: **** Expected EAGAIN, returned success...
        Parent: 13.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: unmap testfile.
        Parent: 13.3  - mmap [               0,            1000] PASSED.
        Parent: 13.4  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: unmap testfile.

Test #14 - Rate test performing I/O on unlocked and locked file.
        Parent: File Unlocked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [542.37 +/- 1.80 KB/s].
        Parent: 14.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: File Locked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [457.14 +/- 1.57 KB/s].
        Parent: 14.1  - F_ULOCK [               0,          ENDING] PASSED.

Test #15 - Test 2nd open and I/O after lock and close.
        Parent: Second open succeeded.
        Parent: 15.0  - F_LOCK  [               0,          ENDING] PASSED.
        Parent: 15.1  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Parent: Wrote 'abcdefghij' to testfile [ 0, 11 ].
        Parent: Read 'abcdefghij' from testfile [ 0, 11 ].
        Parent: 15.2  - COMPARE [               0,               b] PASSED.

** PARENT pass 1 results: 49/49 pass, 1/1 warn, 0/0 fail (pass/total).

**  CHILD pass 1 results: 64/64 pass, 0/0 warn, 0/0 fail (pass/total).

Testing non-native 64 bit LFS locking

Creating parent/child synchronization pipes.

Test #1 - Test regions of an unlocked file.
        Parent: 1.1  - F_TEST  [               0,               1] PASSED.
        Parent: 1.2  - F_TEST  [               0,          ENDING] PASSED.
        Parent: 1.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Parent: 1.4  - F_TEST  [               1,               1] PASSED.
        Parent: 1.5  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 1.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Parent: 1.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Parent: 1.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Parent: 1.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.

Test #2 - Try to lock the whole file.
        Parent: 2.0  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  2.1  - F_TEST  [               0,               1] PASSED.
        Child:  2.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  2.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Child:  2.4  - F_TEST  [               1,               1] PASSED.
        Child:  2.5  - F_TEST  [               1,          ENDING] PASSED.
        Child:  2.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Child:  2.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  2.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  2.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.
        Parent: 2.10 - F_ULOCK [               0,          ENDING] PASSED.

Test #3 - Try to lock just the 1st byte.
        Parent: 3.0  - F_TLOCK [               0,               1] PASSED.
        Child:  3.1  - F_TEST  [               0,               1] PASSED.
        Child:  3.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  3.3  - F_TEST  [               1,               1] PASSED.
        Child:  3.4  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 3.5  - F_ULOCK [               0,               1] PASSED.

Test #4 - Try to lock the 2nd byte, test around it.
        Parent: 4.0  - F_TLOCK [               1,               1] PASSED.
        Child:  4.1  - F_TEST  [               0,               1] PASSED.
        Child:  4.2  - F_TEST  [               0,               2] PASSED.
        Child:  4.3  - F_TEST  [               0,          ENDING] PASSED.
        Child:  4.4  - F_TEST  [               1,               1] PASSED.
        Child:  4.5  - F_TEST  [               1,               2] PASSED.
        Child:  4.6  - F_TEST  [               1,          ENDING] PASSED.
        Child:  4.7  - F_TEST  [               2,               1] PASSED.
        Child:  4.8  - F_TEST  [               2,               2] PASSED.
        Child:  4.9  - F_TEST  [               2,          ENDING] PASSED.
        Parent: 4.10 - F_ULOCK [               1,               1] PASSED.

Test #5 - Try to lock 1st and 2nd bytes, test around them.
        Parent: 5.0  - F_TLOCK [               0,               1] PASSED.
        Parent: 5.1  - F_TLOCK [               2,               1] PASSED.
        Child:  5.2  - F_TEST  [               0,               1] PASSED.
        Child:  5.3  - F_TEST  [               0,               2] PASSED.
        Child:  5.4  - F_TEST  [               0,          ENDING] PASSED.
        Child:  5.5  - F_TEST  [               1,               1] PASSED.
        Child:  5.6  - F_TEST  [               1,               2] PASSED.
        Child:  5.7  - F_TEST  [               1,          ENDING] PASSED.
        Child:  5.8  - F_TEST  [               2,               1] PASSED.
        Child:  5.9  - F_TEST  [               2,               2] PASSED.
        Child:  5.10 - F_TEST  [               2,          ENDING] PASSED.
        Child:  5.11 - F_TEST  [               3,               1] PASSED.
        Child:  5.12 - F_TEST  [               3,               2] PASSED.
        Child:  5.13 - F_TEST  [               3,          ENDING] PASSED.
        Parent: 5.14 - F_ULOCK [               0,               1] PASSED.
        Parent: 5.15 - F_ULOCK [               2,               1] PASSED.

Test #6 - Try to lock the MAXEOF byte.
        Parent: 6.0  - F_TLOCK [7fffffffffffffff,               1] PASSED.
        Child:  6.1  - F_TEST  [7ffffffffffffffe,               1] PASSED.
        Child:  6.2  - F_TEST  [7ffffffffffffffe,               2] PASSED.
        Child:  6.3  - F_TEST  [7ffffffffffffffe,          ENDING] PASSED.
        Child:  6.4  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  6.5  - F_TEST  [7fffffffffffffff,               2] PASSED.
        Child:  6.6  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  6.7  - F_TEST  [8000000000000000,          ENDING] PASSED.
        Child:  6.8  - F_TEST  [8000000000000000,               1] PASSED.
        Child:  6.9  - F_TEST  [8000000000000000,7fffffffffffffff] PASSED.
        Child:  6.10 - F_TEST  [8000000000000000,8000000000000000] PASSED.
        Parent: 6.11 - F_ULOCK [7fffffffffffffff,               1] PASSED.

Test #7 - Test parent/child mutual exclusion.
        Parent: 7.0  - F_TLOCK [             ffc,               9] PASSED.
        Parent: Wrote 'aaaa eh' to testfile [ 4092, 7 ].
        Parent: Now free child to run, should block on lock.
        Parent: Check data in file to insure child blocked.
        Parent: Read 'aaaa eh' from testfile [ 4092, 7 ].
        Parent: 7.1  - COMPARE [             ffc,               7] PASSED.
        Parent: Now unlock region so child will unblock.
        Parent: 7.2  - F_ULOCK [             ffc,               9] PASSED.
        Child:  7.3  - F_LOCK  [             ffc,               9] PASSED.
        Child:  Write child's version of the data and release lock.
        Parent: Now try to regain lock, parent should block.
        Child:  Wrote 'bebebebeb' to testfile [ 4092, 9 ].
        Child:  7.4  - F_ULOCK [             ffc,               9] PASSED.
        Parent: 7.5  - F_LOCK  [             ffc,               9] PASSED.
        Parent: Check data in file to insure child unblocked.
        Parent: Read 'bebebebeb' from testfile [ 4092, 9 ].
        Parent: 7.6  - COMPARE [             ffc,               9] PASSED.
        Parent: 7.7  - F_ULOCK [             ffc,               9] PASSED.

Test #10 - Make sure a locked region is split properly.
        Parent: 10.0  - F_TLOCK [               0,               3] PASSED.
        Parent: 10.1  - F_ULOCK [               1,               1] PASSED.
        Child:  10.2  - F_TEST  [               0,               1] PASSED.
        Child:  10.3  - F_TEST  [               2,               1] PASSED.
        Child:  10.4  - F_TEST  [               3,          ENDING] PASSED.
        Child:  10.5  - F_TEST  [               1,               1] PASSED.
        Parent: 10.6  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.7  - F_ULOCK [               2,               1] PASSED.
        Child:  10.8  - F_TEST  [               0,               3] PASSED.
        Parent: 10.9  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.10 - F_TLOCK [               1,               3] PASSED.
        Parent: 10.11 - F_ULOCK [               2,               1] PASSED.
        Child:  10.12 - F_TEST  [               1,               1] PASSED.
        Child:  10.13 - F_TEST  [               3,               1] PASSED.
        Child:  10.14 - F_TEST  [               4,          ENDING] PASSED.
        Child:  10.15 - F_TEST  [               2,               1] PASSED.
        Child:  10.16 - F_TEST  [               0,               1] PASSED.

Test #11 - Make sure close() releases the process's locks.
        Parent: 11.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Child:  11.1  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: 11.3  - F_TLOCK [              1d,             5b7] PASSED.
        Parent: 11.4  - F_TLOCK [            2000,              57] PASSED.
        Parent: Closed testfile.
        Child:  11.5  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.6  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.7  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 13, 16 ].
        Parent: Closed testfile.
        Child:  11.8  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.9  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.10 - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Truncated testfile.
        Parent: Closed testfile.
        Child:  11.11 - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.12 - F_ULOCK [               0,          ENDING] PASSED.

Test #12 - Signalled process should release locks.
        Child:  12.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Killed child process.
        Parent: 12.1  - F_TLOCK [               0,          ENDING] PASSED.

Test #13 - Check locking and mmap semantics.
        Parent: 13.0  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: 13.1  - mmap [               0,            1000] WARNING!
        Parent: **** Expected EAGAIN, returned success...
        Parent: 13.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: unmap testfile.
        Parent: 13.3  - mmap [               0,            1000] PASSED.
        Parent: 13.4  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: unmap testfile.

Test #14 - Rate test performing I/O on unlocked and locked file.
        Parent: File Unlocked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [530.57 +/- 1.67 KB/s].
        Parent: 14.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: File Locked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [485.31 +/- 8.98 KB/s].
        Parent: 14.1  - F_ULOCK [               0,          ENDING] PASSED.

Test #15 - Test 2nd open and I/O after lock and close.
        Parent: Second open succeeded.
        Parent: 15.0  - F_LOCK  [               0,          ENDING] PASSED.
        Parent: 15.1  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Parent: Wrote 'abcdefghij' to testfile [ 0, 11 ].
        Parent: Read 'abcdefghij' from testfile [ 0, 11 ].
        Parent: 15.2  - COMPARE [               0,               b] PASSED.

** PARENT pass 1 results: 49/49 pass, 1/1 warn, 0/0 fail (pass/total).

**  CHILD pass 1 results: 64/64 pass, 0/0 warn, 0/0 fail (pass/total).
Congratulations, you passed the locking tests!

All tests completed


```
</details>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _None_
- [x] **Code review:** _In progress_
- [X] **Sanity Testing:** _Done as mentioned in testing above_
- [X] **Documentation:** _None_

