### PR TITLE
EOS-15281 :Use m0_log via log_write facility.

### DIFF
--- a/src/cortxfs/cortxfs_fops.c
+++ b/src/cortxfs/cortxfs_fops.c
@@ -31,6 +31,11 @@
 #include "operation.h"
 #include <cfs_perfc.h>
 
+#include <m0log.h>
+
+const int  m0trace_common2 = 2812;
+
+
 int cfs_creat(struct cfs_fh *parent_fh, cfs_cred_t *cred, char *name,
               mode_t mode, cfs_ino_t *newfile_ino)
 {
@@ -168,6 +173,9 @@ static inline ssize_t __cfs_write(struct cfs_fs *cfs_fs, cfs_cred_t *cred,
 	dassert(cfs_fs && cred && fd && buf);
 	dassert(dstore);
 
+	test_m0log_setup();
+        test_m0log_common1_setup((const void*)&m0trace_common2);
+
 	if (count == 0) {
 		rc = 0;
 		goto out;
@@ -212,8 +220,10 @@ out:
 		cfs_fh_destroy_and_dump_stat(fh);
 	}
 
-	log_trace("cfs_fs=%p ino=%llu fd=%p count=%lu offset=%ld rc=%d",
+	log_test("cfs_fs=%p ino=%llu fd=%p count=%lu offset=%ld rc=%d",
 		  cfs_fs, fd->ino, fd, count, (long)offset, rc);
+
+	m0log_fini();
 	return rc;
 }
 

--- a/src/test/ut/CMakeLists.txt
+++ b/src/test/ut/CMakeLists.txt
@@ -95,6 +95,7 @@ target_link_libraries(ut_cortxfs_xattr_dir_ops
 
 target_link_libraries(ut_cortxfs_io_ops
 	ut_cortxfs_helper
+	motr
 )
 
 target_link_libraries(ut_cortxfs_io_bug_ops

--- a/src/test/ut/ut_cortxfs_io_ops.c
+++ b/src/test/ut/ut_cortxfs_io_ops.c
@@ -18,8 +18,11 @@
  */
 
 #include "ut_cortxfs_helper.h"
+#include <m0log.h>
 #define BLOCK_SIZE 4096
 #define IO_ENV_FROM_STATE(__state) (*((struct ut_io_env **)__state))
+
+extern const int  m0trace_common2;
 
 struct ut_io_env {
 	struct ut_cfs_params ut_cfs_obj;
@@ -459,12 +462,18 @@ static int io_ops_teardown(void **state)
 	return rc;
 }
 
-int main(void)
+int main(int argc, char *argv[])
 {
 	int rc = 0;
 	char *test_log = "/var/log/cortx/test/ut/ut_cortxfs.log";
 
 	printf("IO tests\n");
+
+	if (argc > 1 && strcmp(argv[1], "decode") == 0)
+	{
+		rc = decoder((const void*)&m0trace_common2, argv[2], argv[3]);
+		return rc;
+	}
 
 	rc = ut_load_config(CONF_FILE);
 	if (rc != 0) {


### PR DESCRIPTION
EOS-15281 :Use m0_log via log_write facility.
Cortxfs code changes - new code calls the functions from utils and
register the cortxfs module's magical number with m0trace utility.
cortxfs code calls the new function log_test() which will invoke
log_write() and m0_log()
Test ut_cortxfs_io_ops will be invoked to call the new code
added to cortxfs. ut_cortxfs_io_ops will be invoked again
with decode argument and in/out file params.
This should invoke the decoder function in utils
and decode the m0trace file.
Test:
1.compile, reinstall, and setup
2. sudo ./scripts/test.sh
3. sudo rm m0trcae*
4. sudo /tmp/cortxfs/build-cortxfs/test/ut/ut_cortxfs_io_ops
This step generates a m0trace* file.
5. sudo /tmp/cortxfs/build-cortxfs/test/ut/ut_cortxfs_io_ops decode
/home/751565/14790/cortx-posix/m0trace*
/home/751565/14790/cortx-posix/out.txt
output of out.txt:
TEST TEST TEST

Signed-off-by: Shipra <shipra.gupta@seagate.com>