### PR TITLE
EOS-9010: File handle support for cortxfs API's (cortx-fs repo)

### DIFF
--- a/src/cortxfs/cortxfs_fops.c
+++ b/src/cortxfs/cortxfs_fops.c
@@ -108,10 +108,9 @@ int cfs_creat_ex(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent,
 
 	RC_WRAP_LABEL(rc, out, cfs_creat, parent_fh, cred, name, mode,
 		      &object);
-	RC_WRAP_LABEL(rc, cleanup, cfs_setattr, cfs_fs, cred, &object, stat_in,
+	RC_WRAP_LABEL(rc, cleanup, cfs_setattr, parent_fh, cred, stat_in,
 		      stat_in_flags);
-	RC_WRAP_LABEL(rc, cleanup, cfs_getattr, cfs_fs, cred, &object,
-		      stat_out);
+	stat_out = cfs_fh_stat(parent_fh);
 
 	RC_WRAP(kvs_end_transaction, kvstor, &index);
 
@@ -266,8 +265,8 @@ int cfs_truncate(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *ino,
 		new_stat_flags |= (STAT_MTIME_SET | STAT_CTIME_SET);
 	}
 
-	RC_WRAP_LABEL(rc, out, cfs_setattr, cfs_fs, cred, ino, new_stat,
-		      new_stat_flags);
+	RC_WRAP_LABEL(rc, out, cfs_setattr, fh, cred, new_stat,
+			new_stat_flags);
 
 	RC_WRAP_LABEL(rc, out, cfs_ino_to_oid, cfs_fs, ino, &oid);
 	RC_WRAP_LABEL(rc, out, dstore_obj_open, dstore, &oid, &obj);

--- a/src/cortxfs/cortxfs_ops.c
+++ b/src/cortxfs/cortxfs_ops.c
@@ -120,16 +120,15 @@ int cfs_getattr(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
 	return rc;
 }
 
-static inline int __cfs_setattr(struct cfs_fs *cfs_fs, cfs_cred_t *cred,
-                         cfs_ino_t *ino, struct stat *setstat, int statflag)
+static inline int __cfs_setattr(struct cfs_fh *fh, cfs_cred_t *cred,
+				struct stat *setstat, int statflag)
 {
-	struct cfs_fh *fh = NULL;
 	struct stat *stat = NULL;
 	struct timeval t;
 	mode_t ifmt;
 	int rc;
 
-	dassert(cfs_fs && cred && ino && setstat);
+	dassert(cred && setstat);
 
 	if (statflag == 0) {
 		rc = 0;
@@ -139,12 +138,6 @@ static inline int __cfs_setattr(struct cfs_fs *cfs_fs, cfs_cred_t *cred,
 
 	rc = gettimeofday(&t, NULL);
 	dassert(rc == 0);
-
-	/* TODO:Temp_FH_op - to be removed
-	 * Should get rid of creating and destroying FH operation in this
-	 * API when caller pass the valid FH instead of inode number
-	 */
-	RC_WRAP_LABEL(rc, out, cfs_fh_from_ino, cfs_fs, ino, &fh);
 
 	stat = cfs_fh_stat(fh);
 
@@ -193,22 +186,18 @@ static inline int __cfs_setattr(struct cfs_fs *cfs_fs, cfs_cred_t *cred,
 	}
 
 out:
-	if (fh != NULL) {
-		cfs_fh_destroy_and_dump_stat(fh);
-	}
-
 	log_debug("rc=%d", rc);
 	return rc;
 }
 
-int cfs_setattr(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *ino,
+int cfs_setattr(struct cfs_fh *fh, cfs_cred_t *cred,
                 struct stat *setstat, int statflag)
 {
     size_t rc;
 
     perfc_trace_inii(PFT_CFS_SETATTR, PEM_CFS_TO_NFS);
 
-    rc = __cfs_setattr(cfs_fs, cred, ino, setstat, statflag);
+    rc = __cfs_setattr(fh, cred, setstat, statflag);
 
     perfc_trace_attr(PEA_SETATTR_RES_RC, rc);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
@@ -219,12 +208,15 @@ static int __cfs_access(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
 			const cfs_ino_t *ino, int flags)
 {
 	int rc = 0;
-	struct stat stat;
+	struct stat *stat = NULL;;
+	struct cfs_fh *fh = NULL;
 
 	dassert(cred && ino);
 
-	RC_WRAP_LABEL(rc, out, cfs_getattr, cfs_fs, cred, ino, &stat);
-	RC_WRAP_LABEL(rc, out, cfs_access_check, cred, &stat, flags);
+	//RC_WRAP_LABEL(rc, out, cfs_getattr, cfs_fs, cred, ino, &stat);
+	RC_WRAP_LABEL(rc, out, cfs_fh_from_ino, cfs_fs, ino, &fh);
+	stat = cfs_fh_stat(fh);
+	RC_WRAP_LABEL(rc, out, cfs_access_check, cred, stat, flags);
 out:
 	return rc;
 }

--- a/src/include/cortxfs.h
+++ b/src/include/cortxfs.h
@@ -331,7 +331,7 @@ int cfs_getattr(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
  *
  * @return 0 if successful, a negative "-errno" value in case of failure
  */
-int cfs_setattr(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *ino,
+int cfs_setattr(struct cfs_fh *fh, cfs_cred_t *cred,
 		struct stat *setstat, int statflag);
 /**
  * Check is a given user can access an inode.

--- a/src/include/cortxfs.h
+++ b/src/include/cortxfs.h
@@ -295,21 +295,6 @@ struct cfs_inode_attr_key {
 
 /* CORTXFS operations */
 /**
- * Gets attributes for a known inode.
- *
- * @note: the call is similar to stat() call in libc. It uses the structure
- * "struct stat" defined in the libC.
- * @param ctx - Filesystem context
- * @param cred - pointer to user's credentials
- * @param ino - pointer to current inode
- * @param stat - [OUT] points to inode's stat
- *
- * @return 0 if successful, a negative "-errno" value in case of failure
- */
-int cfs_getattr(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
-		const cfs_ino_t *ino, struct stat *stat);
-
-/**
  * Sets attributes for a known inode.
  *
  * This call uses a struct stat structure as input. This structure will

--- a/src/include/internal/error_handler.h
+++ b/src/include/internal/error_handler.h
@@ -18,6 +18,16 @@
  */
 #ifndef ERROR_HANDLER_H_
 #define ERROR_HANDLER_H_
+
+/* User defined error codes set greater than unix error codes.*/
+enum error_code {
+	INVALID_ETAG = 133,		/* Invalid ETag */
+	BAD_DIGEST, 			/* Non-matching HASH */
+	MISSING_ETAG,			/* Object ETag is missing */
+	INVALID_PAYLOAD,		/* Payload data is invalid */
+	INVALID_PATH_PARAMS		/* Invalid REST API path parameters */
+};
+
 /**
  * ############ Error response mapping structure  #####################
  */
@@ -31,12 +41,30 @@ enum error_resp_id {
 	ERR_RES_INVALID_FSNAME = 1,
 	ERR_RES_FS_EXIST,
 
+	/* Response IDs for fs delete api */
+	ERR_RES_FS_NONEXIST,
+	ERR_RES_FS_EXPORT_EXIST,
+	ERR_RES_FS_NOT_EMPTY,
+
+	/* Generic IDs */
+	ERR_RES_INVALID_ETAG,
+	ERR_RES_BAD_DIGEST,
+	ERR_RES_MISSING_ETAG,
+	ERR_RES_INVALID_PAYLOAD,
+	ERR_RES_INVALID_PATH_PARAMS,
+
 	/* Default error response ID */
 	ERR_RES_DEFAULT,
 	ERR_RES_MAX
 };
 
-/* Returns an error response message based on the error code */
+/*
+ *	Mapping APIs corresponding to every REST API
+ *
+ *	Returns an error response message based on the error code
+ */
 const char* fs_create_errno_to_respmsg(int err_code);
+
+const char* fs_delete_errno_to_respmsg(int err_code);
 
 #endif /* ERROR_HANDLER_H_ */

--- a/src/management/error_handler.c
+++ b/src/management/error_handler.c
@@ -22,8 +22,24 @@
 
 const char *error_resp_messages[] = {
 	"Invalid error response ID",
+
+	/* fs create api error response */
 	"The filesystem name specified is not valid.",
 	"The filesystem name you tried to create already exists.",
+
+	/* fs delete api error response */
+	"The specified filesystem does not exist.",
+	"The filesystem you tried to delete is being exported.",
+	"The filesystem you tried to delete is not empty.",
+
+	/* Generic error responses */
+	"The ETag should not be passed for a resource which is not modifiable.",
+	"The HASH specified did not match what we received.",
+	"The Object ETag is not sent.",
+	"Invalid payload data passed.",
+	"Invalid parameters passed with the API path.",
+
+	/* Default error response */
 	"Generic error message. Check cortx logs for more information."
 };
 
@@ -38,6 +54,13 @@ const char* fs_create_errno_to_respmsg(int err_code)
 	case EEXIST:
 		resp_id = ERR_RES_FS_EXIST;
 		break;
+	/* Since filesystem name cannot be modified. */
+	case INVALID_ETAG:
+		resp_id = ERR_RES_INVALID_ETAG;
+		break;
+	case INVALID_PAYLOAD:
+		resp_id = ERR_RES_INVALID_PAYLOAD;
+		break;
 	default:
 		resp_id = ERR_RES_DEFAULT;
 	}
@@ -45,3 +68,35 @@ const char* fs_create_errno_to_respmsg(int err_code)
 	return error_resp_messages[resp_id];
 }
 
+const char* fs_delete_errno_to_respmsg(int err_code)
+{
+	enum error_resp_id resp_id;
+
+	switch (err_code) {
+	case ENOENT:
+		resp_id = ERR_RES_FS_NONEXIST;
+		break;
+	case EINVAL:
+		resp_id = ERR_RES_FS_EXPORT_EXIST;
+		break;
+	case ENOTEMPTY:
+		resp_id = ERR_RES_FS_NOT_EMPTY;
+		break;
+	case BAD_DIGEST:
+		resp_id = ERR_RES_BAD_DIGEST;
+		break;
+	case MISSING_ETAG:
+		resp_id = ERR_RES_MISSING_ETAG;
+		break;
+	case INVALID_PAYLOAD:
+		resp_id = ERR_RES_INVALID_PAYLOAD;
+		break;
+	case INVALID_PATH_PARAMS:
+		resp_id = ERR_RES_INVALID_PATH_PARAMS;
+		break;
+	default:
+		resp_id = ERR_RES_DEFAULT;
+	}
+
+	return error_resp_messages[resp_id];
+}

--- a/src/management/fs.c
+++ b/src/management/fs.c
@@ -31,7 +31,10 @@
 #include "internal/controller.h"
 #include "internal/fs.h"
 #include "internal/error_handler.h"
+#include <limits.h>
 
+#define HASH_MAX_LEN		32
+#define FS_NAME_MAX_LEN		NAME_MAX
 /**
  * ##############################################################
  * #		FS CREATE API'S					#
@@ -83,7 +86,8 @@ static int fs_create_send_response(struct controller_api *fs_create, void *args)
 		resp_code = EVHTP_RES_200;
 
 		rc = md5hash_compute(fs_create_api->resp.fs_name, 
-				     sizeof(fs_create_api->resp.fs_name), 
+				     strnlen(fs_create_api->resp.fs_name, 
+					     FS_NAME_MAX_LEN), 
 				     &hash);
 		if (rc) {
 			resp_code = errno_to_http_code(rc);
@@ -414,6 +418,10 @@ static int fs_delete_process_request(struct controller_api *fs_delete,
 	int fs_name_len = 0;
 	struct request *request = NULL;
 	struct fs_delete_api *fs_delete_api = NULL;
+	const char *fs_name_hash = NULL;
+	struct md5hash hash = MD5HASH_INIT_EMPTY;
+	str256_t hash_str;
+	str256_t request_hash_str;
 
 	request = fs_delete->request;
 
@@ -426,6 +434,8 @@ static int fs_delete_process_request(struct controller_api *fs_delete,
 		fs_delete_send_response(fs_delete, NULL);
 		goto error;
 	}
+
+	fs_name_hash = request_etag_value(request);
 
 	if (request_content_length(request) != 0) {
 		/**
@@ -465,6 +475,53 @@ static int fs_delete_process_request(struct controller_api *fs_delete,
 			 fs_name_len);
 
 	log_debug("Deleting FS : %s.", fs_delete_api->req.fs_name);
+
+	if (fs_name_hash == NULL) {	
+		log_err("Object hash not sent");
+		rc = EINVAL;
+		request_set_errcode(request, rc);
+		fs_create_send_response(fs_delete, NULL);
+		goto error;
+	}
+
+	/* If we ever become multi-threaded, then this might not be sufficient.
+	 * Suppose we recieve 2 simultaneous request then the response to
+	 * one request should be success and the response to another request
+	 * should be "Not Found". In order to achieve this we would need a 
+	 * locking mechanism before we perform this operation. If underlying
+	 * filesystem object has its own locking mechanisms and they can ensure
+	 * that the delete operation can be performed atomically then this
+	 * won't be an issue. */
+	rc = md5hash_compute(fs_delete_api->req.fs_name, 
+			     fs_name_len, 
+			     &hash);
+	if (rc) {
+		log_err("Error Computing hash, rc = %d, fs_name = %s",
+			rc, fs_delete_api->req.fs_name);
+		request_set_errcode(request, rc);
+		fs_create_send_response(fs_delete, NULL);
+		goto error;
+	}
+
+	rc = md5hash_get_string(&hash, &hash_str);
+	if (rc) {
+		log_err("Error getting hash as a string.");
+		request_set_errcode(request, rc);
+		fs_create_send_response(fs_delete, NULL);
+		goto error;
+	}
+
+	str256_from_cstr(request_hash_str, 
+			 fs_name_hash, 
+			 strnlen(fs_name_hash, HASH_MAX_LEN));
+
+	rc = md5hash_validate(&hash_str, &request_hash_str);
+	if (rc) {
+		log_err("Hash does not match");
+		request_set_errcode(request, rc);
+		fs_create_send_response(fs_delete, NULL);
+		goto error;
+	}
 
 	/**
 	 * Send fs delete request to the backend.

--- a/src/test/ut/ut_cortxfs_attr_ops.c
+++ b/src/test/ut/ut_cortxfs_attr_ops.c
@@ -32,6 +32,7 @@
 static void set_ctime(void **state)
 {
 	struct ut_cfs_params *ut_cfs_objs = ENV_FROM_STATE(state);
+	struct cfs_fh *fh = NULL;
 
 	int rc = 0;
 	int flag = STAT_CTIME_SET;
@@ -47,23 +48,21 @@ static void set_ctime(void **state)
 
 	new_ctime = mktime(now_tm);
 
-	struct stat stat_in, stat_out;
+	struct stat stat_in, *stat_out;
 	memset(&stat_in, 0, sizeof(stat_in));
-	memset(&stat_out, 0, sizeof(stat_out));
 
 	stat_in.st_ctim.tv_sec = new_ctime;
 
-	rc = cfs_setattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_in, flag);
-
+	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
+				&fh);
 	ut_assert_int_equal(rc, 0);
 
-	rc = cfs_getattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-			&ut_cfs_objs->file_inode, &stat_out);
+	stat_out = cfs_fh_stat(fh);
 
+	rc = cfs_setattr(fh, &ut_cfs_objs->cred, &stat_in, flag);
 	ut_assert_int_equal(rc, 0);
 
-	ut_assert_int_equal(0, difftime(new_ctime, stat_out.st_ctime));
+	ut_assert_int_equal(0, difftime(new_ctime, stat_out->st_ctime));
 }
 
 /**
@@ -79,6 +78,7 @@ static void set_ctime(void **state)
 static void set_mtime(void **state)
 {
 	struct ut_cfs_params *ut_cfs_objs = ENV_FROM_STATE(state);
+	struct cfs_fh *fh = NULL;
 
 	int rc = 0;
 	int flag = STAT_MTIME_SET;
@@ -94,27 +94,25 @@ static void set_mtime(void **state)
 
 	new_mtime = mktime(now_tm);
 
-	struct stat stat_in,stat_out;
+	struct stat stat_in, *stat_out;
 	memset(&stat_in, 0, sizeof(stat_in));
-	memset(&stat_out, 0, sizeof(stat_out));
 
 	stat_in.st_mtim.tv_sec = new_mtime;
 
 	time(&cur_time);
 
-	rc = cfs_setattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_in, flag);
-
+	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
+				&fh);
 	ut_assert_int_equal(rc, 0);
 
-	rc = cfs_getattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_out);
+	stat_out = cfs_fh_stat(fh);
 
+	rc = cfs_setattr(fh, &ut_cfs_objs->cred, &stat_in, flag);
 	ut_assert_int_equal(rc, 0);
 
-	ut_assert_int_equal(0, difftime(new_mtime, stat_out.st_mtime));
+	ut_assert_int_equal(0, difftime(new_mtime, stat_out->st_mtime));
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
 	}
 }
@@ -132,6 +130,7 @@ static void set_mtime(void **state)
 static void set_atime(void **state)
 {
 	struct ut_cfs_params *ut_cfs_objs = ENV_FROM_STATE(state);
+	struct cfs_fh *fh = NULL;
 
 	int rc = 0;
 	int flag = STAT_ATIME_SET;
@@ -147,26 +146,25 @@ static void set_atime(void **state)
 
 	new_atime = mktime(now_tm);
 
-	struct stat stat_in, stat_out;
+	struct stat stat_in, *stat_out;
 	memset(&stat_in, 0, sizeof(stat_in));
-	memset(&stat_out, 0, sizeof(stat_out));
 
 	stat_in.st_atim.tv_sec = new_atime;
 
 	time(&cur_time);
 
-	rc = cfs_setattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_in, flag);
+	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
+				&fh);
 	ut_assert_int_equal(rc, 0);
 
-	rc = cfs_getattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_out);
+	stat_out = cfs_fh_stat(fh);
 
+	rc = cfs_setattr(fh, &ut_cfs_objs->cred, &stat_in, flag);
 	ut_assert_int_equal(rc, 0);
 
-	ut_assert_int_equal(0, difftime(new_atime, stat_out.st_atime));
+	ut_assert_int_equal(0, difftime(new_atime, stat_out->st_atime));
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
 	}
 }
@@ -184,6 +182,7 @@ static void set_atime(void **state)
 static void set_gid(void **state)
 {
 	struct ut_cfs_params *ut_cfs_objs = ENV_FROM_STATE(state);
+	struct cfs_fh *fh = NULL;
 
 	int rc = 0;
 	int flag = STAT_GID_SET;
@@ -192,27 +191,25 @@ static void set_gid(void **state)
 
 	time_t cur_time;
 
-	struct stat stat_in, stat_out;
+	struct stat stat_in, *stat_out;
 	memset(&stat_in, 0, sizeof(stat_in));
-	memset(&stat_out, 0, sizeof(stat_out));
 
 	stat_in.st_gid = new_gid;
 
 	time(&cur_time);
 
-	rc = cfs_setattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_in, flag);
-
+	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
+				&fh);
 	ut_assert_int_equal(rc, 0);
 
-	rc = cfs_getattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_out);
+	stat_out = cfs_fh_stat(fh);
 
+	rc = cfs_setattr(fh, &ut_cfs_objs->cred, &stat_in, flag);
 	ut_assert_int_equal(rc, 0);
 
-	ut_assert_int_equal(stat_out.st_gid, new_gid);
+	ut_assert_int_equal(stat_out->st_gid, new_gid);
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
 	}
 }
@@ -230,6 +227,7 @@ static void set_gid(void **state)
 static void set_uid(void **state)
 {
 	struct ut_cfs_params *ut_cfs_objs = ENV_FROM_STATE(state);
+	struct cfs_fh *fh = NULL;
 
 	int rc = 0;
 	int flag = STAT_UID_SET;
@@ -238,26 +236,25 @@ static void set_uid(void **state)
 
 	time_t cur_time;
 
-	struct stat stat_in, stat_out;
+	struct stat stat_in, *stat_out;
 	memset(&stat_in, 0, sizeof(stat_in));
-	memset(&stat_out, 0, sizeof(stat_out));
 
 	stat_in.st_uid = new_uid;
 
 	time(&cur_time);
 
-	rc = cfs_setattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_in, flag);
+	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
+				&fh);
 	ut_assert_int_equal(rc, 0);
 
-	rc = cfs_getattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_out);
+	stat_out = cfs_fh_stat(fh);
 
+	rc = cfs_setattr(fh, &ut_cfs_objs->cred, &stat_in, flag);
 	ut_assert_int_equal(rc, 0);
 
-	ut_assert_int_equal(stat_out.st_uid, new_uid);
+	ut_assert_int_equal(stat_out->st_uid, new_uid);
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
 	}
 }

--- a/src/test/ut/ut_cortxfs_attr_ops.c
+++ b/src/test/ut/ut_cortxfs_attr_ops.c
@@ -54,7 +54,7 @@ static void set_ctime(void **state)
 	stat_in.st_ctim.tv_sec = new_ctime;
 
 	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
-				&fh);
+			     &fh);
 	ut_assert_int_equal(rc, 0);
 
 	stat_out = cfs_fh_stat(fh);
@@ -63,6 +63,10 @@ static void set_ctime(void **state)
 	ut_assert_int_equal(rc, 0);
 
 	ut_assert_int_equal(0, difftime(new_ctime, stat_out->st_ctime));
+
+	if (fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(fh);
+	}
 }
 
 /**
@@ -102,7 +106,7 @@ static void set_mtime(void **state)
 	time(&cur_time);
 
 	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
-				&fh);
+			     &fh);
 	ut_assert_int_equal(rc, 0);
 
 	stat_out = cfs_fh_stat(fh);
@@ -114,6 +118,10 @@ static void set_mtime(void **state)
 
 	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
+	}
+
+	if (fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(fh);
 	}
 }
 
@@ -154,7 +162,7 @@ static void set_atime(void **state)
 	time(&cur_time);
 
 	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
-				&fh);
+			     &fh);
 	ut_assert_int_equal(rc, 0);
 
 	stat_out = cfs_fh_stat(fh);
@@ -166,6 +174,10 @@ static void set_atime(void **state)
 
 	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
+	}
+
+	if (fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(fh);
 	}
 }
 
@@ -199,7 +211,7 @@ static void set_gid(void **state)
 	time(&cur_time);
 
 	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
-				&fh);
+			     &fh);
 	ut_assert_int_equal(rc, 0);
 
 	stat_out = cfs_fh_stat(fh);
@@ -211,6 +223,10 @@ static void set_gid(void **state)
 
 	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
+	}
+
+	if (fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(fh);
 	}
 }
 
@@ -244,7 +260,7 @@ static void set_uid(void **state)
 	time(&cur_time);
 
 	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
-				&fh);
+			     &fh);
 	ut_assert_int_equal(rc, 0);
 
 	stat_out = cfs_fh_stat(fh);
@@ -256,6 +272,10 @@ static void set_uid(void **state)
 
 	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
+	}
+
+	if (fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(fh);
 	}
 }
 

--- a/src/test/ut/ut_cortxfs_dir_ops.c
+++ b/src/test/ut/ut_cortxfs_dir_ops.c
@@ -871,34 +871,33 @@ static void create_remove_subdir(void **state)
 	struct ut_cfs_params *ut_cfs_obj = ENV_FROM_STATE(state);
 	cfs_ino_t *pinode =  &ut_cfs_obj->file_inode;
 	cfs_ino_t cinode;
-	struct stat before_create;
-	struct stat after_create;
-	struct stat after_rmdir;
+	struct cfs_fh *parent_fh = NULL;
+	struct stat *before_create = NULL;
+	struct stat *after_create = NULL;
+	struct stat *after_rmdir = NULL;
 
-	memset(&before_create, 0, sizeof(before_create));
-	rc = cfs_getattr(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-			 pinode, &before_create);
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs, pinode, &parent_fh);
 	ut_assert_int_equal(rc, 0);
+	before_create = cfs_fh_stat(parent_fh);
 
 	rc = cfs_mkdir(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
 		       pinode, "childdir", 0755, &cinode);
 	ut_assert_int_equal(rc, 0);
 
-	memset(&after_create, 0, sizeof(after_create));
-	rc = cfs_getattr(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-			 pinode, &after_create);
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs, pinode, &parent_fh);
 	ut_assert_int_equal(rc, 0);
+	after_create = cfs_fh_stat(parent_fh);
 
 	/* if ctime after create has not changed than assert */
-	if (after_create.st_ctim.tv_sec == before_create.st_ctim.tv_sec &&
-	    after_create.st_ctim.tv_nsec == before_create.st_ctim.tv_nsec) {
+	if (after_create->st_ctim.tv_sec == before_create->st_ctim.tv_sec &&
+	    after_create->st_ctim.tv_nsec == before_create->st_ctim.tv_nsec) {
 
 		ut_assert_true(0);
 	}
 
 	/* if mtime after create has not changed than assert */
-	if (after_create.st_mtim.tv_sec == before_create.st_mtim.tv_sec &&
-	    after_create.st_mtim.tv_nsec == before_create.st_mtim.tv_nsec) {
+	if (after_create->st_mtim.tv_sec == before_create->st_mtim.tv_sec &&
+	    after_create->st_mtim.tv_nsec == before_create->st_mtim.tv_nsec) {
 
 		ut_assert_true(0);
 	}
@@ -907,20 +906,19 @@ static void create_remove_subdir(void **state)
 		       pinode, "childdir");
 	ut_assert_int_equal(rc, 0);
 
-	memset(&after_rmdir, 0, sizeof(after_rmdir));
-	rc = cfs_getattr(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-			 pinode, &after_rmdir);
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs, pinode, &parent_fh);
 	ut_assert_int_equal(rc, 0);
+	after_rmdir = cfs_fh_stat(parent_fh);
 
 	/* if ctime after rmdir has not changed than assert */
-	if (after_rmdir.st_ctim.tv_sec == after_create.st_ctim.tv_sec &&
-	    after_rmdir.st_ctim.tv_nsec == after_create.st_ctim.tv_nsec) {
+	if (after_rmdir->st_ctim.tv_sec == after_create->st_ctim.tv_sec &&
+	    after_rmdir->st_ctim.tv_nsec == after_create->st_ctim.tv_nsec) {
 
 		ut_assert_true(0);
 	}
 	/* if mtime after rmdir has not changed than assert */
-	if (after_rmdir.st_mtim.tv_sec == after_create.st_mtim.tv_sec &&
-	    after_rmdir.st_mtim.tv_nsec == after_create.st_mtim.tv_nsec) {
+	if (after_rmdir->st_mtim.tv_sec == after_create->st_mtim.tv_sec &&
+	    after_rmdir->st_mtim.tv_nsec == after_create->st_mtim.tv_nsec) {
 
 		ut_assert_true(0);
 	}

--- a/src/test/ut/ut_cortxfs_dir_ops.c
+++ b/src/test/ut/ut_cortxfs_dir_ops.c
@@ -932,11 +932,7 @@ static void create_remove_subdir(void **state)
 		cfs_fh_destroy(pfh_after_create);
 	}
 	if (pfh_after_rmdir != NULL) {
-		/* This test does not update parent FH after
-		 * creating child dir, but should it do?
-		 * If no, then below should not dump stat.
-		 */
-		cfs_fh_destroy_and_dump_stat(pfh_after_rmdir);
+		cfs_fh_destroy(pfh_after_rmdir);
 	}
 }
 

--- a/src/test/ut/ut_cortxfs_link_ops.c
+++ b/src/test/ut/ut_cortxfs_link_ops.c
@@ -216,14 +216,14 @@ static void create_hardlink(void **state)
 	int rc = 0;
 	char *link_name = "test_hardlink";
 	cfs_ino_t file_inode = 0LL;
+	struct cfs_fh *fh = NULL;
 
 	struct ut_link_env *ut_link_obj = LINK_ENV_FROM_STATE(state);
 	struct ut_cfs_params *ut_cfs_obj = &ut_link_obj->ut_cfs_obj;
 
 	ut_link_obj->link_name = link_name;
 
-	struct stat stat_out;
-	memset(&stat_out, 0, sizeof(stat_out));
+	struct stat *stat_out;
 
 	time_t cur_time;
 	time(&cur_time);
@@ -242,14 +242,14 @@ static void create_hardlink(void **state)
 
 	ut_assert_int_equal(ut_cfs_obj->file_inode, file_inode);
 
-	rc = cfs_getattr(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-			&ut_cfs_obj->file_inode, &stat_out);
-
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs,
+				&ut_cfs_obj->file_inode, &fh);
 	ut_assert_int_equal(rc, 0);
+	stat_out = cfs_fh_stat(fh);
 
-	ut_assert_int_equal(stat_out.st_nlink, 2);
+	ut_assert_int_equal(stat_out->st_nlink, 2);
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
 	} 
 }
@@ -270,6 +270,7 @@ static void create_longname255_hardlink(void **state)
 {
 	int rc = 0;
 	cfs_ino_t file_inode = 0LL;
+	struct cfs_fh *fh = NULL;
 
 	char *long_name = "123456789012345678901234567890123456789012345678901"
 			"123456789012345678901234567890123456789012345678901"
@@ -282,8 +283,7 @@ static void create_longname255_hardlink(void **state)
 
 	ut_link_obj->link_name = long_name;
 
-	struct stat stat_out;
-	memset(&stat_out, 0, sizeof(stat_out));
+	struct stat *stat_out;
 
 	time_t cur_time;
 	time(&cur_time);
@@ -304,14 +304,14 @@ static void create_longname255_hardlink(void **state)
 
 	ut_assert_int_equal(ut_cfs_obj->file_inode, file_inode);
 
-	rc = cfs_getattr(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-			&ut_cfs_obj->file_inode, &stat_out);
-
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs,
+				&ut_cfs_obj->file_inode, &fh);
 	ut_assert_int_equal(rc, 0);
+	stat_out = cfs_fh_stat(fh);
 
-	ut_assert_int_equal(stat_out.st_nlink, 2);
+	ut_assert_int_equal(stat_out->st_nlink, 2);
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
 	} 
 }
@@ -341,6 +341,7 @@ static void create_hardlink_delete_original(void **state)
 	ut_link_obj->link_name = link_name;
 
 	cfs_ino_t link_inode = 0LL;
+	struct cfs_fh *fh = NULL;
 	time_t cur_time;
 
 	rc = cfs_link(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
@@ -365,17 +366,16 @@ static void create_hardlink_delete_original(void **state)
 	
 	time(&cur_time);
 
-	struct stat stat_out;
-	memset(&stat_out, 0, sizeof(stat_out));
+	struct stat *stat_out;
 
-	rc = cfs_getattr(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-				&ut_cfs_obj->file_inode, &stat_out);
-
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs,
+				&ut_cfs_obj->file_inode, &fh);
 	ut_assert_int_equal(rc, 0);
+	stat_out = cfs_fh_stat(fh);
 
-	ut_assert_int_equal(stat_out.st_nlink, 1);
+	ut_assert_int_equal(stat_out->st_nlink, 1);
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
 	}
 }
@@ -406,6 +406,7 @@ static void create_hardlink_delete_link(void **state)
 	time_t cur_time;
 
 	cfs_ino_t file_inode = 0LL;
+	struct cfs_fh *fh = NULL;
 
 	rc = cfs_link(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
 			&ut_cfs_obj->file_inode, &ut_cfs_obj->current_inode,
@@ -429,15 +430,14 @@ static void create_hardlink_delete_link(void **state)
 
 	ut_link_obj->link_name = NULL;
 
-	struct stat stat_out;
-	memset(&stat_out, '0', sizeof(stat_out));
+	struct stat *stat_out;
 
-	rc = cfs_getattr(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-				&ut_cfs_obj->file_inode, &stat_out);
-
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs,
+				&ut_cfs_obj->file_inode, &fh);
 	ut_assert_int_equal(rc, 0);
+	stat_out = cfs_fh_stat(fh);
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
 	}
 }

--- a/src/test/ut/ut_cortxfs_link_ops.c
+++ b/src/test/ut/ut_cortxfs_link_ops.c
@@ -252,6 +252,10 @@ static void create_hardlink(void **state)
 	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
 	} 
+
+	if (fh != NULL) {
+		cfs_fh_destroy(fh);
+	}
 }
 
 /**
@@ -314,6 +318,10 @@ static void create_longname255_hardlink(void **state)
 	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
 	} 
+
+	if (fh != NULL) {
+		cfs_fh_destroy(fh);
+	}
 }
 
 /**
@@ -378,6 +386,10 @@ static void create_hardlink_delete_original(void **state)
 	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
 	}
+
+	if (fh != NULL) {
+		cfs_fh_destroy(fh);
+	}
 }
 
 /**
@@ -439,6 +451,10 @@ static void create_hardlink_delete_link(void **state)
 
 	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
+	}
+
+	if (fh != NULL) {
+		cfs_fh_destroy(fh);
 	}
 }
 


### PR DESCRIPTION
# cortx-fs Change Summary

## Problem Statement
_[EOS-9010](https://jts.seagate.com/browse/EOS-9010):_
_File handle support for cortxfs API's_

## Problem Description
_The current implementation relies on cfs_fs and inode, that should be eliminated_

## Solution Overview
_Modified relevant API's to use FH_

## Unit Test Cases
_Build, UT testing, ensure no errors_

## Testing
<details>
  <summary>Click here to see the build output</summary>

```
[root@ssc-vm-c-0689 cortx-posix]# ./scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

```

</details>


## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _None_
- [ ] **Code review:** _In progress_
- [x] **Sanity Testing:** _Completed as mentioned above_
- [ ] **Documentation:** _TBD_

Relevant PR's for this :
https://github.com/Seagate/cortx-posix/pull/295
https://github.com/Seagate/cortx-fs-ganesha/pull/59