### PR TITLE
EOS-9010: File handle support for cortxfs API's (cortx-fs repo)

### DIFF
--- a/src/cortxfs/cortxfs_fops.c
+++ b/src/cortxfs/cortxfs_fops.c
@@ -81,8 +81,8 @@ int cfs_creat_ex(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent,
 		 int stat_in_flags, cfs_ino_t *newfile,
 		 struct stat *stat_out)
 {
-	int rc, rc2;
-	cfs_ino_t object = 0;
+	int rc;
+	cfs_ino_t child_ino = 0;
 	struct cfs_fh *parent_fh = NULL;
 	struct cfs_fh *child_fh = NULL;
 	struct kvstore *kvstor = kvstore_get();
@@ -107,46 +107,41 @@ int cfs_creat_ex(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *parent,
 	RC_WRAP(kvs_begin_transaction, kvstor, &index);
 
 	RC_WRAP_LABEL(rc, out, cfs_creat, parent_fh, cred, name, mode,
-		      &object);
-	RC_WRAP_LABEL(rc, cleanup, cfs_setattr, cfs_fs, cred, &object, stat_in,
+		      &child_ino);
+	RC_WRAP_LABEL(rc, cleanup, cfs_fh_from_ino,
+		      cfs_fs, &child_ino, &child_fh);
+	RC_WRAP_LABEL(rc, cleanup, cfs_setattr, child_fh, cred, stat_in,
 		      stat_in_flags);
-	RC_WRAP_LABEL(rc, cleanup, cfs_getattr, cfs_fs, cred, &object,
-		      stat_out);
+	memcpy(stat_out, cfs_fh_stat(child_fh), sizeof(struct stat));
 
 	RC_WRAP(kvs_end_transaction, kvstor, &index);
 
-	*newfile = object;
-	object = 0;
+	*newfile = child_ino;
+	child_ino = 0;
 
 cleanup:
-	if (object != 0) {
-		rc2 = cfs_fh_from_ino(cfs_fs, &object, &child_fh);
-		/* Atleast we should be able to construct FH otherwise not
-		 * possible to operate further
-		 */
-		dassert(rc2 == 0);
-
+	if (child_ino != 0) {
 		/* We don't have transactions, so that let's just remove the
-		 * object.
+		 * child_ino.
 		 */
 		(void) cfs_unlink2(parent_fh, child_fh, cred, name);
 		(void) kvs_discard_transaction(kvstor, &index);
 
-		if (child_fh != NULL) {
-			cfs_fh_destroy(child_fh);
-		}
-
-		log_err("cfs_fs=%p parent_ino=%llu object=%llu name=%s rc=%d"
-			"rc2=%d", cfs_fs, *parent, object, name, rc, rc2);
+		log_err("cfs_fs=%p parent_ino=%llu child_ino=%llu name=%s rc=%d",
+			cfs_fs, *parent, child_ino, name, rc);
 	}
 
 out:
+	if (child_fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(child_fh);
+	}
+
 	if (parent_fh != NULL) {
 		cfs_fh_destroy_and_dump_stat(parent_fh);
 	}
 
 	log_debug("cfs_fs=%p parent_ino=%llu new_ino=%llu name=%s rc=%d",
-		  cfs_fs, *parent, rc==0 ? *newfile : object, name, rc);
+		  cfs_fs, *parent, rc==0 ? *newfile : child_ino, name, rc);
 
 	perfc_trace_attr(PEA_CFS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
@@ -266,8 +261,8 @@ int cfs_truncate(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *ino,
 		new_stat_flags |= (STAT_MTIME_SET | STAT_CTIME_SET);
 	}
 
-	RC_WRAP_LABEL(rc, out, cfs_setattr, cfs_fs, cred, ino, new_stat,
-		      new_stat_flags);
+	RC_WRAP_LABEL(rc, out, cfs_setattr, fh, cred, new_stat,
+			new_stat_flags);
 
 	RC_WRAP_LABEL(rc, out, cfs_ino_to_oid, cfs_fs, ino, &oid);
 	RC_WRAP_LABEL(rc, out, dstore_obj_open, dstore, &oid, &obj);
@@ -279,7 +274,7 @@ out:
 	}
 
 	if (fh != NULL) {
-		cfs_fh_destroy(fh);
+		cfs_fh_destroy_and_dump_stat(fh);
 	}
 
 	return rc;

--- a/src/cortxfs/cortxfs_ops.c
+++ b/src/cortxfs/cortxfs_ops.c
@@ -78,58 +78,15 @@ int cfs_set_stat(struct kvnode *node)
 	return rc;
 }
 
-static inline int __cfs_getattr(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
-			 const cfs_ino_t *ino, struct stat *bufstat)
+static inline int __cfs_setattr(struct cfs_fh *fh, cfs_cred_t *cred,
+				struct stat *setstat, int statflag)
 {
-	int rc;
-	struct stat *stat = NULL;
-	struct cfs_fh *fh = NULL;
-
-	dassert(cfs_fs && cred && ino && bufstat);
-
-	/* TODO:Temp_FH_op - to be removed
-	 * Should get rid of creating and destroying FH operation in this
-	 * API when caller pass the valid FH instead of inode number
-	 */
-	RC_WRAP_LABEL(rc, out, cfs_fh_from_ino, cfs_fs, ino, &fh);
-
-	stat = cfs_fh_stat(fh);
-
-	memcpy(bufstat, stat, sizeof(struct stat));
-out:
-	if (fh != NULL) {
-		cfs_fh_destroy_and_dump_stat(fh);
-	}
-
-	log_debug("ino=%d rc=%d", (int)bufstat->st_ino, rc);
-	return rc;
-}
-
-int cfs_getattr(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
-		const cfs_ino_t *ino, struct stat *bufstat)
-{
-	size_t rc;
-
-	perfc_trace_inii(PFT_CFS_GETATTR, PEM_CFS_TO_NFS);
-
-	rc = __cfs_getattr(cfs_fs, cred, ino, bufstat);
-
-	perfc_trace_attr(PEA_GETATTR_RES_RC, rc);
-	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-
-	return rc;
-}
-
-static inline int __cfs_setattr(struct cfs_fs *cfs_fs, cfs_cred_t *cred,
-                         cfs_ino_t *ino, struct stat *setstat, int statflag)
-{
-	struct cfs_fh *fh = NULL;
 	struct stat *stat = NULL;
 	struct timeval t;
 	mode_t ifmt;
 	int rc;
 
-	dassert(cfs_fs && cred && ino && setstat);
+	dassert(cred && setstat && fh);
 
 	if (statflag == 0) {
 		rc = 0;
@@ -139,12 +96,6 @@ static inline int __cfs_setattr(struct cfs_fs *cfs_fs, cfs_cred_t *cred,
 
 	rc = gettimeofday(&t, NULL);
 	dassert(rc == 0);
-
-	/* TODO:Temp_FH_op - to be removed
-	 * Should get rid of creating and destroying FH operation in this
-	 * API when caller pass the valid FH instead of inode number
-	 */
-	RC_WRAP_LABEL(rc, out, cfs_fh_from_ino, cfs_fs, ino, &fh);
 
 	stat = cfs_fh_stat(fh);
 
@@ -193,22 +144,18 @@ static inline int __cfs_setattr(struct cfs_fs *cfs_fs, cfs_cred_t *cred,
 	}
 
 out:
-	if (fh != NULL) {
-		cfs_fh_destroy_and_dump_stat(fh);
-	}
-
 	log_debug("rc=%d", rc);
 	return rc;
 }
 
-int cfs_setattr(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *ino,
+int cfs_setattr(struct cfs_fh *fh, cfs_cred_t *cred,
                 struct stat *setstat, int statflag)
 {
     size_t rc;
 
     perfc_trace_inii(PFT_CFS_SETATTR, PEM_CFS_TO_NFS);
 
-    rc = __cfs_setattr(cfs_fs, cred, ino, setstat, statflag);
+    rc = __cfs_setattr(fh, cred, setstat, statflag);
 
     perfc_trace_attr(PEA_SETATTR_RES_RC, rc);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
@@ -219,12 +166,14 @@ static int __cfs_access(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
 			const cfs_ino_t *ino, int flags)
 {
 	int rc = 0;
-	struct stat stat;
+	struct stat *stat = NULL;;
+	struct cfs_fh *fh = NULL;
 
 	dassert(cred && ino);
 
-	RC_WRAP_LABEL(rc, out, cfs_getattr, cfs_fs, cred, ino, &stat);
-	RC_WRAP_LABEL(rc, out, cfs_access_check, cred, &stat, flags);
+	RC_WRAP_LABEL(rc, out, cfs_fh_from_ino, cfs_fs, ino, &fh);
+	stat = cfs_fh_stat(fh);
+	RC_WRAP_LABEL(rc, out, cfs_access_check, cred, stat, flags);
 out:
 	return rc;
 }

--- a/src/cortxfs/cortxfs_ops.c
+++ b/src/cortxfs/cortxfs_ops.c
@@ -78,6 +78,38 @@ int cfs_set_stat(struct kvnode *node)
 	return rc;
 }
 
+static inline int __cfs_getattr(struct cfs_fh *cfs_fh, struct stat *bufstat)
+{
+	int rc = 0;
+	struct stat *stat = NULL;
+
+	dassert(cfs_fh && bufstat);
+
+	stat = cfs_fh_stat(cfs_fh);
+	if (stat == NULL) {
+		rc = -1;
+	}
+
+	memcpy(bufstat, stat, sizeof(struct stat));
+
+	log_debug("ino=%d rc=%d", (int)bufstat->st_ino, rc);
+	return rc;
+}
+
+int cfs_getattr(struct cfs_fh *cfs_fh, struct stat *bufstat)
+{
+	size_t rc;
+
+	perfc_trace_inii(PFT_CFS_GETATTR, PEM_CFS_TO_NFS);
+
+	rc = __cfs_getattr(cfs_fh, bufstat);
+
+	perfc_trace_attr(PEA_GETATTR_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
+	return rc;
+}
+
 static inline int __cfs_setattr(struct cfs_fh *fh, cfs_cred_t *cred,
 				struct stat *setstat, int statflag)
 {

--- a/src/include/cortxfs.h
+++ b/src/include/cortxfs.h
@@ -295,7 +295,19 @@ struct cfs_inode_attr_key {
 
 /* CORTXFS operations */
 /**
- * Sets attributes for a known inode.
+ * Gets attributes for a known file handle.
+ *
+ * @note: the call is similar to stat() call in libc. It uses the structure
+ * "struct stat" defined in the libC.
+ * @param fh - File handle
+ * @param stat - [OUT] points to inode's stat
+ *
+ * @return 0 if successful, a negative "-errno" value in case of failure
+ */
+int cfs_getattr(struct cfs_fh *cfs_fh, struct stat *stat);
+
+/**
+ * Sets attributes for a known file handle.
  *
  * This call uses a struct stat structure as input. This structure will
  * contain the values to be set. More than one can be set in a single call.
@@ -308,9 +320,8 @@ struct cfs_inode_attr_key {
  *  STAT_MTIME_SET: sets mtime
  *  STAT_CTIME_SET: set ctime
  *
- * @param ctx - Filesystem context
+ * @param fh - File handle
  * @param cred - pointer to user's credentials
- * @param ino - pointer to current inode
  * @param setstat - a stat structure containing the new values
  * @param statflags - a bitmap that tells which attributes are to be set
  *

--- a/src/include/cortxfs.h
+++ b/src/include/cortxfs.h
@@ -295,21 +295,6 @@ struct cfs_inode_attr_key {
 
 /* CORTXFS operations */
 /**
- * Gets attributes for a known inode.
- *
- * @note: the call is similar to stat() call in libc. It uses the structure
- * "struct stat" defined in the libC.
- * @param ctx - Filesystem context
- * @param cred - pointer to user's credentials
- * @param ino - pointer to current inode
- * @param stat - [OUT] points to inode's stat
- *
- * @return 0 if successful, a negative "-errno" value in case of failure
- */
-int cfs_getattr(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
-		const cfs_ino_t *ino, struct stat *stat);
-
-/**
  * Sets attributes for a known inode.
  *
  * This call uses a struct stat structure as input. This structure will
@@ -331,7 +316,7 @@ int cfs_getattr(struct cfs_fs *cfs_fs, const cfs_cred_t *cred,
  *
  * @return 0 if successful, a negative "-errno" value in case of failure
  */
-int cfs_setattr(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *ino,
+int cfs_setattr(struct cfs_fh *fh, cfs_cred_t *cred,
 		struct stat *setstat, int statflag);
 /**
  * Check is a given user can access an inode.

--- a/src/test/ut/ut_cortxfs_attr_ops.c
+++ b/src/test/ut/ut_cortxfs_attr_ops.c
@@ -32,6 +32,7 @@
 static void set_ctime(void **state)
 {
 	struct ut_cfs_params *ut_cfs_objs = ENV_FROM_STATE(state);
+	struct cfs_fh *fh = NULL;
 
 	int rc = 0;
 	int flag = STAT_CTIME_SET;
@@ -47,23 +48,25 @@ static void set_ctime(void **state)
 
 	new_ctime = mktime(now_tm);
 
-	struct stat stat_in, stat_out;
+	struct stat stat_in, *stat_out;
 	memset(&stat_in, 0, sizeof(stat_in));
-	memset(&stat_out, 0, sizeof(stat_out));
 
 	stat_in.st_ctim.tv_sec = new_ctime;
 
-	rc = cfs_setattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_in, flag);
-
+	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
+			     &fh);
 	ut_assert_int_equal(rc, 0);
 
-	rc = cfs_getattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-			&ut_cfs_objs->file_inode, &stat_out);
+	stat_out = cfs_fh_stat(fh);
 
+	rc = cfs_setattr(fh, &ut_cfs_objs->cred, &stat_in, flag);
 	ut_assert_int_equal(rc, 0);
 
-	ut_assert_int_equal(0, difftime(new_ctime, stat_out.st_ctime));
+	ut_assert_int_equal(0, difftime(new_ctime, stat_out->st_ctime));
+
+	if (fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(fh);
+	}
 }
 
 /**
@@ -79,6 +82,7 @@ static void set_ctime(void **state)
 static void set_mtime(void **state)
 {
 	struct ut_cfs_params *ut_cfs_objs = ENV_FROM_STATE(state);
+	struct cfs_fh *fh = NULL;
 
 	int rc = 0;
 	int flag = STAT_MTIME_SET;
@@ -94,28 +98,30 @@ static void set_mtime(void **state)
 
 	new_mtime = mktime(now_tm);
 
-	struct stat stat_in,stat_out;
+	struct stat stat_in, *stat_out;
 	memset(&stat_in, 0, sizeof(stat_in));
-	memset(&stat_out, 0, sizeof(stat_out));
 
 	stat_in.st_mtim.tv_sec = new_mtime;
 
 	time(&cur_time);
 
-	rc = cfs_setattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_in, flag);
-
+	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
+			     &fh);
 	ut_assert_int_equal(rc, 0);
 
-	rc = cfs_getattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_out);
+	stat_out = cfs_fh_stat(fh);
 
+	rc = cfs_setattr(fh, &ut_cfs_objs->cred, &stat_in, flag);
 	ut_assert_int_equal(rc, 0);
 
-	ut_assert_int_equal(0, difftime(new_mtime, stat_out.st_mtime));
+	ut_assert_int_equal(0, difftime(new_mtime, stat_out->st_mtime));
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
+	}
+
+	if (fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(fh);
 	}
 }
 
@@ -132,6 +138,7 @@ static void set_mtime(void **state)
 static void set_atime(void **state)
 {
 	struct ut_cfs_params *ut_cfs_objs = ENV_FROM_STATE(state);
+	struct cfs_fh *fh = NULL;
 
 	int rc = 0;
 	int flag = STAT_ATIME_SET;
@@ -147,27 +154,30 @@ static void set_atime(void **state)
 
 	new_atime = mktime(now_tm);
 
-	struct stat stat_in, stat_out;
+	struct stat stat_in, *stat_out;
 	memset(&stat_in, 0, sizeof(stat_in));
-	memset(&stat_out, 0, sizeof(stat_out));
 
 	stat_in.st_atim.tv_sec = new_atime;
 
 	time(&cur_time);
 
-	rc = cfs_setattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_in, flag);
+	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
+			     &fh);
 	ut_assert_int_equal(rc, 0);
 
-	rc = cfs_getattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_out);
+	stat_out = cfs_fh_stat(fh);
 
+	rc = cfs_setattr(fh, &ut_cfs_objs->cred, &stat_in, flag);
 	ut_assert_int_equal(rc, 0);
 
-	ut_assert_int_equal(0, difftime(new_atime, stat_out.st_atime));
+	ut_assert_int_equal(0, difftime(new_atime, stat_out->st_atime));
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
+	}
+
+	if (fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(fh);
 	}
 }
 
@@ -184,6 +194,7 @@ static void set_atime(void **state)
 static void set_gid(void **state)
 {
 	struct ut_cfs_params *ut_cfs_objs = ENV_FROM_STATE(state);
+	struct cfs_fh *fh = NULL;
 
 	int rc = 0;
 	int flag = STAT_GID_SET;
@@ -192,28 +203,30 @@ static void set_gid(void **state)
 
 	time_t cur_time;
 
-	struct stat stat_in, stat_out;
+	struct stat stat_in, *stat_out;
 	memset(&stat_in, 0, sizeof(stat_in));
-	memset(&stat_out, 0, sizeof(stat_out));
 
 	stat_in.st_gid = new_gid;
 
 	time(&cur_time);
 
-	rc = cfs_setattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_in, flag);
-
+	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
+			     &fh);
 	ut_assert_int_equal(rc, 0);
 
-	rc = cfs_getattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_out);
+	stat_out = cfs_fh_stat(fh);
 
+	rc = cfs_setattr(fh, &ut_cfs_objs->cred, &stat_in, flag);
 	ut_assert_int_equal(rc, 0);
 
-	ut_assert_int_equal(stat_out.st_gid, new_gid);
+	ut_assert_int_equal(stat_out->st_gid, new_gid);
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
+	}
+
+	if (fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(fh);
 	}
 }
 
@@ -230,6 +243,7 @@ static void set_gid(void **state)
 static void set_uid(void **state)
 {
 	struct ut_cfs_params *ut_cfs_objs = ENV_FROM_STATE(state);
+	struct cfs_fh *fh = NULL;
 
 	int rc = 0;
 	int flag = STAT_UID_SET;
@@ -238,27 +252,30 @@ static void set_uid(void **state)
 
 	time_t cur_time;
 
-	struct stat stat_in, stat_out;
+	struct stat stat_in, *stat_out;
 	memset(&stat_in, 0, sizeof(stat_in));
-	memset(&stat_out, 0, sizeof(stat_out));
 
 	stat_in.st_uid = new_uid;
 
 	time(&cur_time);
 
-	rc = cfs_setattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_in, flag);
+	rc = cfs_fh_from_ino(ut_cfs_objs->cfs_fs, &ut_cfs_objs->file_inode,
+			     &fh);
 	ut_assert_int_equal(rc, 0);
 
-	rc = cfs_getattr(ut_cfs_objs->cfs_fs, &ut_cfs_objs->cred,
-				&ut_cfs_objs->file_inode, &stat_out);
+	stat_out = cfs_fh_stat(fh);
 
+	rc = cfs_setattr(fh, &ut_cfs_objs->cred, &stat_in, flag);
 	ut_assert_int_equal(rc, 0);
 
-	ut_assert_int_equal(stat_out.st_uid, new_uid);
+	ut_assert_int_equal(stat_out->st_uid, new_uid);
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
+	}
+
+	if (fh != NULL) {
+		cfs_fh_destroy_and_dump_stat(fh);
 	}
 }
 

--- a/src/test/ut/ut_cortxfs_dir_ops.c
+++ b/src/test/ut/ut_cortxfs_dir_ops.c
@@ -871,34 +871,35 @@ static void create_remove_subdir(void **state)
 	struct ut_cfs_params *ut_cfs_obj = ENV_FROM_STATE(state);
 	cfs_ino_t *pinode =  &ut_cfs_obj->file_inode;
 	cfs_ino_t cinode;
-	struct stat before_create;
-	struct stat after_create;
-	struct stat after_rmdir;
+	struct cfs_fh *pfh_before_create = NULL;
+	struct cfs_fh *pfh_after_create = NULL;
+	struct cfs_fh *pfh_after_rmdir = NULL;
+	struct stat *before_create = NULL;
+	struct stat *after_create = NULL;
+	struct stat *after_rmdir = NULL;
 
-	memset(&before_create, 0, sizeof(before_create));
-	rc = cfs_getattr(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-			 pinode, &before_create);
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs, pinode, &pfh_before_create);
 	ut_assert_int_equal(rc, 0);
+	before_create = cfs_fh_stat(pfh_before_create);
 
 	rc = cfs_mkdir(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
 		       pinode, "childdir", 0755, &cinode);
 	ut_assert_int_equal(rc, 0);
 
-	memset(&after_create, 0, sizeof(after_create));
-	rc = cfs_getattr(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-			 pinode, &after_create);
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs, pinode, &pfh_after_create);
 	ut_assert_int_equal(rc, 0);
+	after_create = cfs_fh_stat(pfh_after_create);
 
 	/* if ctime after create has not changed than assert */
-	if (after_create.st_ctim.tv_sec == before_create.st_ctim.tv_sec &&
-	    after_create.st_ctim.tv_nsec == before_create.st_ctim.tv_nsec) {
+	if (after_create->st_ctim.tv_sec == before_create->st_ctim.tv_sec &&
+	    after_create->st_ctim.tv_nsec == before_create->st_ctim.tv_nsec) {
 
 		ut_assert_true(0);
 	}
 
 	/* if mtime after create has not changed than assert */
-	if (after_create.st_mtim.tv_sec == before_create.st_mtim.tv_sec &&
-	    after_create.st_mtim.tv_nsec == before_create.st_mtim.tv_nsec) {
+	if (after_create->st_mtim.tv_sec == before_create->st_mtim.tv_sec &&
+	    after_create->st_mtim.tv_nsec == before_create->st_mtim.tv_nsec) {
 
 		ut_assert_true(0);
 	}
@@ -907,22 +908,31 @@ static void create_remove_subdir(void **state)
 		       pinode, "childdir");
 	ut_assert_int_equal(rc, 0);
 
-	memset(&after_rmdir, 0, sizeof(after_rmdir));
-	rc = cfs_getattr(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-			 pinode, &after_rmdir);
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs, pinode, &pfh_after_rmdir);
 	ut_assert_int_equal(rc, 0);
+	after_rmdir = cfs_fh_stat(pfh_after_rmdir);
 
 	/* if ctime after rmdir has not changed than assert */
-	if (after_rmdir.st_ctim.tv_sec == after_create.st_ctim.tv_sec &&
-	    after_rmdir.st_ctim.tv_nsec == after_create.st_ctim.tv_nsec) {
+	if (after_rmdir->st_ctim.tv_sec == after_create->st_ctim.tv_sec &&
+	    after_rmdir->st_ctim.tv_nsec == after_create->st_ctim.tv_nsec) {
 
 		ut_assert_true(0);
 	}
 	/* if mtime after rmdir has not changed than assert */
-	if (after_rmdir.st_mtim.tv_sec == after_create.st_mtim.tv_sec &&
-	    after_rmdir.st_mtim.tv_nsec == after_create.st_mtim.tv_nsec) {
+	if (after_rmdir->st_mtim.tv_sec == after_create->st_mtim.tv_sec &&
+	    after_rmdir->st_mtim.tv_nsec == after_create->st_mtim.tv_nsec) {
 
 		ut_assert_true(0);
+	}
+
+	if (pfh_before_create != NULL) {
+		cfs_fh_destroy(pfh_before_create);
+	}
+	if (pfh_after_create != NULL) {
+		cfs_fh_destroy(pfh_after_create);
+	}
+	if (pfh_after_rmdir != NULL) {
+		cfs_fh_destroy(pfh_after_rmdir);
 	}
 }
 

--- a/src/test/ut/ut_cortxfs_link_ops.c
+++ b/src/test/ut/ut_cortxfs_link_ops.c
@@ -377,7 +377,7 @@ static void create_hardlink_delete_original(void **state)
 	struct stat *stat_out;
 
 	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs,
-				&ut_cfs_obj->file_inode, &fh);
+			     &ut_cfs_obj->file_inode, &fh);
 	ut_assert_int_equal(rc, 0);
 	stat_out = cfs_fh_stat(fh);
 
@@ -445,7 +445,7 @@ static void create_hardlink_delete_link(void **state)
 	struct stat *stat_out;
 
 	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs,
-				&ut_cfs_obj->file_inode, &fh);
+			     &ut_cfs_obj->file_inode, &fh);
 	ut_assert_int_equal(rc, 0);
 	stat_out = cfs_fh_stat(fh);
 

--- a/src/test/ut/ut_cortxfs_link_ops.c
+++ b/src/test/ut/ut_cortxfs_link_ops.c
@@ -216,14 +216,14 @@ static void create_hardlink(void **state)
 	int rc = 0;
 	char *link_name = "test_hardlink";
 	cfs_ino_t file_inode = 0LL;
+	struct cfs_fh *fh = NULL;
 
 	struct ut_link_env *ut_link_obj = LINK_ENV_FROM_STATE(state);
 	struct ut_cfs_params *ut_cfs_obj = &ut_link_obj->ut_cfs_obj;
 
 	ut_link_obj->link_name = link_name;
 
-	struct stat stat_out;
-	memset(&stat_out, 0, sizeof(stat_out));
+	struct stat *stat_out;
 
 	time_t cur_time;
 	time(&cur_time);
@@ -242,16 +242,20 @@ static void create_hardlink(void **state)
 
 	ut_assert_int_equal(ut_cfs_obj->file_inode, file_inode);
 
-	rc = cfs_getattr(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-			&ut_cfs_obj->file_inode, &stat_out);
-
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs,
+				&ut_cfs_obj->file_inode, &fh);
 	ut_assert_int_equal(rc, 0);
+	stat_out = cfs_fh_stat(fh);
 
-	ut_assert_int_equal(stat_out.st_nlink, 2);
+	ut_assert_int_equal(stat_out->st_nlink, 2);
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
 	} 
+
+	if (fh != NULL) {
+		cfs_fh_destroy(fh);
+	}
 }
 
 /**
@@ -270,6 +274,7 @@ static void create_longname255_hardlink(void **state)
 {
 	int rc = 0;
 	cfs_ino_t file_inode = 0LL;
+	struct cfs_fh *fh = NULL;
 
 	char *long_name = "123456789012345678901234567890123456789012345678901"
 			"123456789012345678901234567890123456789012345678901"
@@ -282,8 +287,7 @@ static void create_longname255_hardlink(void **state)
 
 	ut_link_obj->link_name = long_name;
 
-	struct stat stat_out;
-	memset(&stat_out, 0, sizeof(stat_out));
+	struct stat *stat_out;
 
 	time_t cur_time;
 	time(&cur_time);
@@ -304,16 +308,20 @@ static void create_longname255_hardlink(void **state)
 
 	ut_assert_int_equal(ut_cfs_obj->file_inode, file_inode);
 
-	rc = cfs_getattr(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-			&ut_cfs_obj->file_inode, &stat_out);
-
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs,
+				&ut_cfs_obj->file_inode, &fh);
 	ut_assert_int_equal(rc, 0);
+	stat_out = cfs_fh_stat(fh);
 
-	ut_assert_int_equal(stat_out.st_nlink, 2);
+	ut_assert_int_equal(stat_out->st_nlink, 2);
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
 	} 
+
+	if (fh != NULL) {
+		cfs_fh_destroy(fh);
+	}
 }
 
 /**
@@ -341,6 +349,7 @@ static void create_hardlink_delete_original(void **state)
 	ut_link_obj->link_name = link_name;
 
 	cfs_ino_t link_inode = 0LL;
+	struct cfs_fh *fh = NULL;
 	time_t cur_time;
 
 	rc = cfs_link(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
@@ -365,18 +374,21 @@ static void create_hardlink_delete_original(void **state)
 	
 	time(&cur_time);
 
-	struct stat stat_out;
-	memset(&stat_out, 0, sizeof(stat_out));
+	struct stat *stat_out;
 
-	rc = cfs_getattr(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-				&ut_cfs_obj->file_inode, &stat_out);
-
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs,
+				&ut_cfs_obj->file_inode, &fh);
 	ut_assert_int_equal(rc, 0);
+	stat_out = cfs_fh_stat(fh);
 
-	ut_assert_int_equal(stat_out.st_nlink, 1);
+	ut_assert_int_equal(stat_out->st_nlink, 1);
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
+	}
+
+	if (fh != NULL) {
+		cfs_fh_destroy(fh);
 	}
 }
 
@@ -406,6 +418,7 @@ static void create_hardlink_delete_link(void **state)
 	time_t cur_time;
 
 	cfs_ino_t file_inode = 0LL;
+	struct cfs_fh *fh = NULL;
 
 	rc = cfs_link(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
 			&ut_cfs_obj->file_inode, &ut_cfs_obj->current_inode,
@@ -429,16 +442,19 @@ static void create_hardlink_delete_link(void **state)
 
 	ut_link_obj->link_name = NULL;
 
-	struct stat stat_out;
-	memset(&stat_out, '0', sizeof(stat_out));
+	struct stat *stat_out;
 
-	rc = cfs_getattr(ut_cfs_obj->cfs_fs, &ut_cfs_obj->cred,
-				&ut_cfs_obj->file_inode, &stat_out);
-
+	rc = cfs_fh_from_ino(ut_cfs_obj->cfs_fs,
+				&ut_cfs_obj->file_inode, &fh);
 	ut_assert_int_equal(rc, 0);
+	stat_out = cfs_fh_stat(fh);
 
-	if(difftime(stat_out.st_ctime, cur_time) < 0) {
+	if(difftime(stat_out->st_ctime, cur_time) < 0) {
 		ut_assert_true(0);
+	}
+
+	if (fh != NULL) {
+		cfs_fh_destroy(fh);
 	}
 }
 


### PR DESCRIPTION
# cortx-fs Change Summary

## Problem Statement
_[EOS-9010](https://jts.seagate.com/browse/EOS-9010):_
_File handle support for cortxfs API's_

## Problem Description
_The current implementation relies on cfs_fs and inode, that should be eliminated_

## Solution Overview
_Modified relevant API's to use FH_

## Unit Test Cases
_Build, UT testing, ensure no errors_

## Testing
<details>
  <summary>Click here to see the script test output</summary>

```
[root@ssc-vm-c-1561 cortx-posix-9010]# ./scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

```

</details>

<details>
  <summary>Click here to see the cthon output</summary>

```
[root@ssc-vm-c-1561 cortx-posix-9010]# /opt/seagate/cortx/fs-ganesha/test/run_cthon.sh -m /mnt/dir1 -p testFS -a
sh ./runtests  -a -t /mnt/dir1/ssc-vm-c-1561.test

Starting BASIC tests: test directory /mnt/dir1/ssc-vm-c-1561.test (arg: -t)

./test1: File and directory creation test
        created 4 files 2 directories 2 levels deep in 0.20 seconds
        ./test1 ok.

./test2: File and directory removal test
        removed 4 files 2 directories 2 levels deep in 0.17 seconds
        ./test2 ok.

./test3: lookups across mount point
        500 getcwd and stat calls in 0.0  seconds
        ./test3 ok.

./test4: setattr, getattr, and lookup
        1000 chmods and stats on 10 files in 6.32 seconds
        ./test4 ok.
./test4a: getattr and lookup
        1000 stats on 10 files in 0.1  seconds
        ./test4a ok.

TESTARG=-t
./test6: readdir
        7500 entries read, 120 files in 45.25 seconds
        ./test6 ok.

./test7: link and rename
        200 renames and links on 10 files in 9.35 seconds
        ./test7 ok.

./test8: symlink and readlink
        400 symlinks and readlinks on 10 files in 9.30 seconds
        ./test8 ok.

./test9: statfs
        1500 statfs calls in 2.64 seconds
        ./test9 ok.

Congratulations, you passed the basic tests!

GENERAL TESTS: directory /mnt/dir1/ssc-vm-c-1561.test
if test ! -x runtests; then chmod a+x runtests; fi
cd /mnt/dir1/ssc-vm-c-1561.test; rm -f Makefile runtests runtests.wrk *.sh *.c mkdummy rmdummy nroff.in makefile.tst
cp Makefile runtests runtests.wrk *.sh *.c mkdummy rmdummy nroff.in makefile.tst /mnt/dir1/ssc-vm-c-1561.test

Small Compile
smcomp.time
        0.1 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Tbl
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Nroff
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Large Compile
        0.1 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Four simultaneous large compiles
        0.2 (0.0) real  0.1 (0.0) user  0.0 (0.0) sys

Makefile
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

General tests complete

SPECIAL TESTS: directory /mnt/dir1/ssc-vm-c-1561.test
cd /mnt/dir1/ssc-vm-c-1561.test; rm -f runtests runtests.wrk READWIN.txt Makefile op_unlk op_ren op_chmod dupreq excltest negseek rename holey truncate nfsidem nstat stat stat2 touchn fstat rewind telldir bigfile bigfile2 freesp
cp runtests runtests.wrk READWIN.txt Makefile op_unlk op_ren op_chmod dupreq excltest negseek rename holey truncate nfsidem nstat stat stat2 touchn fstat rewind telldir bigfile bigfile2 freesp /mnt/dir1/ssc-vm-c-1561.test

check for proper open/unlink operation
nfsjunk files before unlink:
  -rw-rw-rw- 1 root root 0 Dec  7 23:38 ./nfsjDkmDx
./nfsjDkmDx open; unlink ret = 0
nfsjunk files after unlink:
  ls: cannot access ./nfsjDkmDx: No such file or directory
data compare ok
nfsjunk files after close:
  ls: cannot access ./nfsjDkmDx: No such file or directory
test completed successfully.

check for proper open/rename operation
nfsjunk files before rename:
  -rwxrwxrwx 1 root root 0 Dec  7 23:38 ./nfsa5GBf2F
  -rwxrwxrwx 1 root root 0 Dec  7 23:38 ./nfsbG3CFdx
./nfsbG3CFdx open; rename ret = 0
nfsjunk files after rename:
  ls: cannot access ./nfsa5GBf2F: No such file or directory
  -rwxrwxrwx 1 root root 0 Dec  7 23:38 ./nfsbG3CFdx
data compare ok
nfsjunk files after close:
  ls: cannot access ./nfsa5GBf2F: No such file or directory
  ls: cannot access ./nfsbG3CFdx: No such file or directory
test completed successfully.

check for proper open/chmod 0 operation
testfile before chmod:
  -rw-rw-rw- 1 root root 0 Dec  7 23:38 ./nfsmvZiw3
./nfsmvZiw3 open; chmod ret = 0
testfile after chmod:
  ---------- 1 root root 0 Dec  7 23:38 ./nfsmvZiw3
data compare ok
testfile after write/read:
  ---------- 1 root root 100 Dec  7 23:38 ./nfsmvZiw3
test completed successfully.

check for lost reply on non-idempotent requests
100 tries

test exclusive create.

test negative seek, you should get: read: Invalid argument
or lseek: Invalid argument
lseek: Invalid argument

test rename

test truncate
truncate succeeded

test holey file support
Holey file test ok

second check for lost reply on non-idempotent requests
testing 50 idempotencies in directory "testdir"

test rewind support

test telldir cookies

test freesp and file size
fcntl(...F_FREESP...) not available on this platform.

write/read 30 MB file

write/read at 2GB, 4GB edges

Special tests complete

Starting LOCKING tests: test directory /mnt/dir1/ssc-vm-c-1561.test (arg: -t)

Testing native post-LFS locking

Creating parent/child synchronization pipes.

Test #1 - Test regions of an unlocked file.
        Parent: 1.1  - F_TEST  [               0,               1] PASSED.
        Parent: 1.2  - F_TEST  [               0,          ENDING] PASSED.
        Parent: 1.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Parent: 1.4  - F_TEST  [               1,               1] PASSED.
        Parent: 1.5  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 1.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Parent: 1.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Parent: 1.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Parent: 1.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.

Test #2 - Try to lock the whole file.
        Parent: 2.0  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  2.1  - F_TEST  [               0,               1] PASSED.
        Child:  2.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  2.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Child:  2.4  - F_TEST  [               1,               1] PASSED.
        Child:  2.5  - F_TEST  [               1,          ENDING] PASSED.
        Child:  2.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Child:  2.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  2.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  2.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.
        Parent: 2.10 - F_ULOCK [               0,          ENDING] PASSED.

Test #3 - Try to lock just the 1st byte.
        Parent: 3.0  - F_TLOCK [               0,               1] PASSED.
        Child:  3.1  - F_TEST  [               0,               1] PASSED.
        Child:  3.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  3.3  - F_TEST  [               1,               1] PASSED.
        Child:  3.4  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 3.5  - F_ULOCK [               0,               1] PASSED.

Test #4 - Try to lock the 2nd byte, test around it.
        Parent: 4.0  - F_TLOCK [               1,               1] PASSED.
        Child:  4.1  - F_TEST  [               0,               1] PASSED.
        Child:  4.2  - F_TEST  [               0,               2] PASSED.
        Child:  4.3  - F_TEST  [               0,          ENDING] PASSED.
        Child:  4.4  - F_TEST  [               1,               1] PASSED.
        Child:  4.5  - F_TEST  [               1,               2] PASSED.
        Child:  4.6  - F_TEST  [               1,          ENDING] PASSED.
        Child:  4.7  - F_TEST  [               2,               1] PASSED.
        Child:  4.8  - F_TEST  [               2,               2] PASSED.
        Child:  4.9  - F_TEST  [               2,          ENDING] PASSED.
        Parent: 4.10 - F_ULOCK [               1,               1] PASSED.

Test #5 - Try to lock 1st and 2nd bytes, test around them.
        Parent: 5.0  - F_TLOCK [               0,               1] PASSED.
        Parent: 5.1  - F_TLOCK [               2,               1] PASSED.
        Child:  5.2  - F_TEST  [               0,               1] PASSED.
        Child:  5.3  - F_TEST  [               0,               2] PASSED.
        Child:  5.4  - F_TEST  [               0,          ENDING] PASSED.
        Child:  5.5  - F_TEST  [               1,               1] PASSED.
        Child:  5.6  - F_TEST  [               1,               2] PASSED.
        Child:  5.7  - F_TEST  [               1,          ENDING] PASSED.
        Child:  5.8  - F_TEST  [               2,               1] PASSED.
        Child:  5.9  - F_TEST  [               2,               2] PASSED.
        Child:  5.10 - F_TEST  [               2,          ENDING] PASSED.
        Child:  5.11 - F_TEST  [               3,               1] PASSED.
        Child:  5.12 - F_TEST  [               3,               2] PASSED.
        Child:  5.13 - F_TEST  [               3,          ENDING] PASSED.
        Parent: 5.14 - F_ULOCK [               0,               1] PASSED.
        Parent: 5.15 - F_ULOCK [               2,               1] PASSED.

Test #6 - Try to lock the MAXEOF byte.
        Parent: 6.0  - F_TLOCK [7fffffffffffffff,               1] PASSED.
        Child:  6.1  - F_TEST  [7ffffffffffffffe,               1] PASSED.
        Child:  6.2  - F_TEST  [7ffffffffffffffe,               2] PASSED.
        Child:  6.3  - F_TEST  [7ffffffffffffffe,          ENDING] PASSED.
        Child:  6.4  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  6.5  - F_TEST  [7fffffffffffffff,               2] PASSED.
        Child:  6.6  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  6.7  - F_TEST  [8000000000000000,          ENDING] PASSED.
        Child:  6.8  - F_TEST  [8000000000000000,               1] PASSED.
        Child:  6.9  - F_TEST  [8000000000000000,7fffffffffffffff] PASSED.
        Child:  6.10 - F_TEST  [8000000000000000,8000000000000000] PASSED.
        Parent: 6.11 - F_ULOCK [7fffffffffffffff,               1] PASSED.

Test #7 - Test parent/child mutual exclusion.
        Parent: 7.0  - F_TLOCK [             ffc,               9] PASSED.
        Parent: Wrote 'aaaa eh' to testfile [ 4092, 7 ].
        Parent: Now free child to run, should block on lock.
        Parent: Check data in file to insure child blocked.
        Parent: Read 'aaaa eh' from testfile [ 4092, 7 ].
        Parent: 7.1  - COMPARE [             ffc,               7] PASSED.
        Parent: Now unlock region so child will unblock.
        Parent: 7.2  - F_ULOCK [             ffc,               9] PASSED.
        Child:  7.3  - F_LOCK  [             ffc,               9] PASSED.
        Child:  Write child's version of the data and release lock.
        Parent: Now try to regain lock, parent should block.
        Child:  Wrote 'bebebebeb' to testfile [ 4092, 9 ].
        Child:  7.4  - F_ULOCK [             ffc,               9] PASSED.
        Parent: 7.5  - F_LOCK  [             ffc,               9] PASSED.
        Parent: Check data in file to insure child unblocked.
        Parent: Read 'bebebebeb' from testfile [ 4092, 9 ].
        Parent: 7.6  - COMPARE [             ffc,               9] PASSED.
        Parent: 7.7  - F_ULOCK [             ffc,               9] PASSED.

Test #8 - Rate test performing lock/unlock cycles.
        Parent: Performed 1000 lock/unlock cycles in 3280 msecs. [36585 lpm].

Test #10 - Make sure a locked region is split properly.
        Parent: 10.0  - F_TLOCK [               0,               3] PASSED.
        Parent: 10.1  - F_ULOCK [               1,               1] PASSED.
        Child:  10.2  - F_TEST  [               0,               1] PASSED.
        Child:  10.3  - F_TEST  [               2,               1] PASSED.
        Child:  10.4  - F_TEST  [               3,          ENDING] PASSED.
        Child:  10.5  - F_TEST  [               1,               1] PASSED.
        Parent: 10.6  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.7  - F_ULOCK [               2,               1] PASSED.
        Child:  10.8  - F_TEST  [               0,               3] PASSED.
        Parent: 10.9  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.10 - F_TLOCK [               1,               3] PASSED.
        Parent: 10.11 - F_ULOCK [               2,               1] PASSED.
        Child:  10.12 - F_TEST  [               1,               1] PASSED.
        Child:  10.13 - F_TEST  [               3,               1] PASSED.
        Child:  10.14 - F_TEST  [               4,          ENDING] PASSED.
        Child:  10.15 - F_TEST  [               2,               1] PASSED.
        Child:  10.16 - F_TEST  [               0,               1] PASSED.

Test #11 - Make sure close() releases the process's locks.
        Parent: 11.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Child:  11.1  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: 11.3  - F_TLOCK [              1d,             5b7] PASSED.
        Parent: 11.4  - F_TLOCK [            2000,              57] PASSED.
        Parent: Closed testfile.
        Child:  11.5  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.6  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.7  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 13, 16 ].
        Parent: Closed testfile.
        Child:  11.8  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.9  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.10 - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Truncated testfile.
        Parent: Closed testfile.
        Child:  11.11 - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.12 - F_ULOCK [               0,          ENDING] PASSED.

Test #12 - Signalled process should release locks.
        Child:  12.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Killed child process.
        Parent: 12.1  - F_TLOCK [               0,          ENDING] PASSED.

Test #13 - Check locking and mmap semantics.
        Parent: 13.0  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: 13.1  - mmap [               0,            1000] WARNING!
        Parent: **** Expected EAGAIN, returned success...
        Parent: 13.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: unmap testfile.
        Parent: 13.3  - mmap [               0,            1000] PASSED.
        Parent: 13.4  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: unmap testfile.

Test #14 - Rate test performing I/O on unlocked and locked file.
        Parent: File Unlocked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [499.03 +/- 1.56 KB/s].
        Parent: 14.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: File Locked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [473.64 +/- 8.00 KB/s].
        Parent: 14.1  - F_ULOCK [               0,          ENDING] PASSED.

Test #15 - Test 2nd open and I/O after lock and close.
        Parent: Second open succeeded.
        Parent: 15.0  - F_LOCK  [               0,          ENDING] PASSED.
        Parent: 15.1  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Parent: Wrote 'abcdefghij' to testfile [ 0, 11 ].
        Parent: Read 'abcdefghij' from testfile [ 0, 11 ].
        Parent: 15.2  - COMPARE [               0,               b] PASSED.

** PARENT pass 1 results: 49/49 pass, 1/1 warn, 0/0 fail (pass/total).

**  CHILD pass 1 results: 64/64 pass, 0/0 warn, 0/0 fail (pass/total).

Testing non-native 64 bit LFS locking

Creating parent/child synchronization pipes.

Test #1 - Test regions of an unlocked file.
        Parent: 1.1  - F_TEST  [               0,               1] PASSED.
        Parent: 1.2  - F_TEST  [               0,          ENDING] PASSED.
        Parent: 1.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Parent: 1.4  - F_TEST  [               1,               1] PASSED.
        Parent: 1.5  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 1.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Parent: 1.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Parent: 1.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Parent: 1.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.

Test #2 - Try to lock the whole file.
        Parent: 2.0  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  2.1  - F_TEST  [               0,               1] PASSED.
        Child:  2.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  2.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Child:  2.4  - F_TEST  [               1,               1] PASSED.
        Child:  2.5  - F_TEST  [               1,          ENDING] PASSED.
        Child:  2.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Child:  2.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  2.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  2.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.
        Parent: 2.10 - F_ULOCK [               0,          ENDING] PASSED.

Test #3 - Try to lock just the 1st byte.
        Parent: 3.0  - F_TLOCK [               0,               1] PASSED.
        Child:  3.1  - F_TEST  [               0,               1] PASSED.
        Child:  3.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  3.3  - F_TEST  [               1,               1] PASSED.
        Child:  3.4  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 3.5  - F_ULOCK [               0,               1] PASSED.

Test #4 - Try to lock the 2nd byte, test around it.
        Parent: 4.0  - F_TLOCK [               1,               1] PASSED.
        Child:  4.1  - F_TEST  [               0,               1] PASSED.
        Child:  4.2  - F_TEST  [               0,               2] PASSED.
        Child:  4.3  - F_TEST  [               0,          ENDING] PASSED.
        Child:  4.4  - F_TEST  [               1,               1] PASSED.
        Child:  4.5  - F_TEST  [               1,               2] PASSED.
        Child:  4.6  - F_TEST  [               1,          ENDING] PASSED.
        Child:  4.7  - F_TEST  [               2,               1] PASSED.
        Child:  4.8  - F_TEST  [               2,               2] PASSED.
        Child:  4.9  - F_TEST  [               2,          ENDING] PASSED.
        Parent: 4.10 - F_ULOCK [               1,               1] PASSED.

Test #5 - Try to lock 1st and 2nd bytes, test around them.
        Parent: 5.0  - F_TLOCK [               0,               1] PASSED.
        Parent: 5.1  - F_TLOCK [               2,               1] PASSED.
        Child:  5.2  - F_TEST  [               0,               1] PASSED.
        Child:  5.3  - F_TEST  [               0,               2] PASSED.
        Child:  5.4  - F_TEST  [               0,          ENDING] PASSED.
        Child:  5.5  - F_TEST  [               1,               1] PASSED.
        Child:  5.6  - F_TEST  [               1,               2] PASSED.
        Child:  5.7  - F_TEST  [               1,          ENDING] PASSED.
        Child:  5.8  - F_TEST  [               2,               1] PASSED.
        Child:  5.9  - F_TEST  [               2,               2] PASSED.
        Child:  5.10 - F_TEST  [               2,          ENDING] PASSED.
        Child:  5.11 - F_TEST  [               3,               1] PASSED.
        Child:  5.12 - F_TEST  [               3,               2] PASSED.
        Child:  5.13 - F_TEST  [               3,          ENDING] PASSED.
        Parent: 5.14 - F_ULOCK [               0,               1] PASSED.
        Parent: 5.15 - F_ULOCK [               2,               1] PASSED.

Test #6 - Try to lock the MAXEOF byte.
        Parent: 6.0  - F_TLOCK [7fffffffffffffff,               1] PASSED.
        Child:  6.1  - F_TEST  [7ffffffffffffffe,               1] PASSED.
        Child:  6.2  - F_TEST  [7ffffffffffffffe,               2] PASSED.
        Child:  6.3  - F_TEST  [7ffffffffffffffe,          ENDING] PASSED.
        Child:  6.4  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  6.5  - F_TEST  [7fffffffffffffff,               2] PASSED.
        Child:  6.6  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  6.7  - F_TEST  [8000000000000000,          ENDING] PASSED.
        Child:  6.8  - F_TEST  [8000000000000000,               1] PASSED.
        Child:  6.9  - F_TEST  [8000000000000000,7fffffffffffffff] PASSED.
        Child:  6.10 - F_TEST  [8000000000000000,8000000000000000] PASSED.
        Parent: 6.11 - F_ULOCK [7fffffffffffffff,               1] PASSED.

Test #7 - Test parent/child mutual exclusion.
        Parent: 7.0  - F_TLOCK [             ffc,               9] PASSED.
        Parent: Wrote 'aaaa eh' to testfile [ 4092, 7 ].
        Parent: Now free child to run, should block on lock.
        Parent: Check data in file to insure child blocked.
        Parent: Read 'aaaa eh' from testfile [ 4092, 7 ].
        Parent: 7.1  - COMPARE [             ffc,               7] PASSED.
        Parent: Now unlock region so child will unblock.
        Parent: 7.2  - F_ULOCK [             ffc,               9] PASSED.
        Child:  7.3  - F_LOCK  [             ffc,               9] PASSED.
        Child:  Write child's version of the data and release lock.
        Parent: Now try to regain lock, parent should block.
        Child:  Wrote 'bebebebeb' to testfile [ 4092, 9 ].
        Child:  7.4  - F_ULOCK [             ffc,               9] PASSED.
        Parent: 7.5  - F_LOCK  [             ffc,               9] PASSED.
        Parent: Check data in file to insure child unblocked.
        Parent: Read 'bebebebeb' from testfile [ 4092, 9 ].
        Parent: 7.6  - COMPARE [             ffc,               9] PASSED.
        Parent: 7.7  - F_ULOCK [             ffc,               9] PASSED.

Test #8 - Rate test performing lock/unlock cycles.
        Parent: Performed 1000 lock/unlock cycles in 3140 msecs. [38216 lpm].

Test #10 - Make sure a locked region is split properly.
        Parent: 10.0  - F_TLOCK [               0,               3] PASSED.
        Parent: 10.1  - F_ULOCK [               1,               1] PASSED.
        Child:  10.2  - F_TEST  [               0,               1] PASSED.
        Child:  10.3  - F_TEST  [               2,               1] PASSED.
        Child:  10.4  - F_TEST  [               3,          ENDING] PASSED.
        Child:  10.5  - F_TEST  [               1,               1] PASSED.
        Parent: 10.6  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.7  - F_ULOCK [               2,               1] PASSED.
        Child:  10.8  - F_TEST  [               0,               3] PASSED.
        Parent: 10.9  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.10 - F_TLOCK [               1,               3] PASSED.
        Parent: 10.11 - F_ULOCK [               2,               1] PASSED.
        Child:  10.12 - F_TEST  [               1,               1] PASSED.
        Child:  10.13 - F_TEST  [               3,               1] PASSED.
        Child:  10.14 - F_TEST  [               4,          ENDING] PASSED.
        Child:  10.15 - F_TEST  [               2,               1] PASSED.
        Child:  10.16 - F_TEST  [               0,               1] PASSED.

Test #11 - Make sure close() releases the process's locks.
        Parent: 11.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Child:  11.1  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: 11.3  - F_TLOCK [              1d,             5b7] PASSED.
        Parent: 11.4  - F_TLOCK [            2000,              57] PASSED.
        Parent: Closed testfile.
        Child:  11.5  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.6  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.7  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 13, 16 ].
        Parent: Closed testfile.
        Child:  11.8  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.9  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.10 - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Truncated testfile.
        Parent: Closed testfile.
        Child:  11.11 - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.12 - F_ULOCK [               0,          ENDING] PASSED.

Test #12 - Signalled process should release locks.
        Child:  12.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Killed child process.
        Parent: 12.1  - F_TLOCK [               0,          ENDING] PASSED.

Test #13 - Check locking and mmap semantics.
        Parent: 13.0  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: 13.1  - mmap [               0,            1000] WARNING!
        Parent: **** Expected EAGAIN, returned success...
        Parent: 13.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: unmap testfile.
        Parent: 13.3  - mmap [               0,            1000] PASSED.
        Parent: 13.4  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: unmap testfile.

Test #14 - Rate test performing I/O on unlocked and locked file.
        Parent: File Unlocked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [490.89 +/- 1.59 KB/s].
        Parent: 14.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: File Locked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [460.43 +/- 6.94 KB/s].
        Parent: 14.1  - F_ULOCK [               0,          ENDING] PASSED.

Test #15 - Test 2nd open and I/O after lock and close.
        Parent: Second open succeeded.
        Parent: 15.0  - F_LOCK  [               0,          ENDING] PASSED.
        Parent: 15.1  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Parent: Wrote 'abcdefghij' to testfile [ 0, 11 ].
        Parent: Read 'abcdefghij' from testfile [ 0, 11 ].
        Parent: 15.2  - COMPARE [               0,               b] PASSED.

** PARENT pass 1 results: 49/49 pass, 1/1 warn, 0/0 fail (pass/total).

**  CHILD pass 1 results: 64/64 pass, 0/0 warn, 0/0 fail (pass/total).
Congratulations, you passed the locking tests!

All tests completed

```

</details>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _None_
- [x] **Code review:** _In progress_
- [x] **Sanity Testing:** _Completed as mentioned above_
- [ ] **Documentation:** _TBD_

Relevant PR's for this :
https://github.com/Seagate/cortx-posix/pull/299
https://github.com/Seagate/cortx-fs-ganesha/pull/60